### PR TITLE
feat: add workflow and repository services

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,20 @@
 export type { DatabaseType } from './db/index';
 export { createConnection, getAppliedVersions, getDbPath, runMigrations } from './db/index';
+export {
+  isValidWorkflowTransition,
+  repositoryService,
+  WORKFLOW_TRANSITIONS,
+  workflowService,
+} from './services/index';
+export type {
+  CreateParams,
+  GetOptions,
+  ListFilters,
+  PlanTask,
+  SetPlanParams,
+  SetPlanResult,
+  WorkflowWithTasks,
+} from './services/workflow.service';
 export type {
   Agent,
   AgentRole,

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,0 +1,3 @@
+export * as repositoryService from './repository.service';
+export { isValidWorkflowTransition, WORKFLOW_TRANSITIONS } from './transitions';
+export * as workflowService from './workflow.service';

--- a/packages/core/src/services/repository.service.test.ts
+++ b/packages/core/src/services/repository.service.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DatabaseType } from '../db/connection';
+import { createConnection } from '../db/connection';
+import { runMigrations } from '../db/migrations';
+import * as repositoryService from './repository.service';
+
+describe('repositoryService', () => {
+  let db: DatabaseType;
+
+  beforeEach(() => {
+    db = createConnection(':memory:');
+    runMigrations(db);
+  });
+
+  describe('register', () => {
+    it('creates a new repository', () => {
+      const repo = repositoryService.register(db, { path: '/home/user/project' });
+      expect(repo.path).toBe('/home/user/project');
+      expect(repo.name).toBeNull();
+      expect(repo.id).toMatch(/^rp_[0-9a-z]{12}$/);
+    });
+
+    it('returns existing repository when re-registering same path', () => {
+      const first = repositoryService.register(db, { path: '/home/user/project' });
+      const second = repositoryService.register(db, { path: '/home/user/project' });
+      expect(second.id).toBe(first.id);
+      expect(second.created_at).toBe(first.created_at);
+    });
+
+    it('accepts an optional name', () => {
+      const repo = repositoryService.register(db, {
+        path: '/home/user/project',
+        name: 'my-project',
+      });
+      expect(repo.name).toBe('my-project');
+    });
+
+    it('sets created_at and updated_at timestamps', () => {
+      const before = Date.now();
+      const repo = repositoryService.register(db, { path: '/home/user/project' });
+      const after = Date.now();
+      expect(repo.created_at).toBeGreaterThanOrEqual(before);
+      expect(repo.created_at).toBeLessThanOrEqual(after);
+      expect(repo.updated_at).toBe(repo.created_at);
+    });
+
+    it('creates distinct repositories for different paths', () => {
+      const a = repositoryService.register(db, { path: '/a' });
+      const b = repositoryService.register(db, { path: '/b' });
+      expect(a.id).not.toBe(b.id);
+    });
+  });
+
+  describe('list', () => {
+    it('returns empty list when no repositories exist', () => {
+      const result = repositoryService.list(db);
+      expect(result.repositories).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('returns all repositories with correct total', () => {
+      repositoryService.register(db, { path: '/first' });
+      repositoryService.register(db, { path: '/second' });
+      repositoryService.register(db, { path: '/third' });
+
+      const result = repositoryService.list(db);
+      expect(result.repositories).toHaveLength(3);
+      expect(result.total).toBe(3);
+      const paths = result.repositories.map((r) => r.path);
+      expect(paths).toContain('/first');
+      expect(paths).toContain('/second');
+      expect(paths).toContain('/third');
+    });
+
+    it('respects limit and offset', () => {
+      for (let i = 0; i < 5; i++) {
+        repositoryService.register(db, { path: `/repo-${i}` });
+      }
+
+      const page1 = repositoryService.list(db, { limit: 2, offset: 0 });
+      expect(page1.repositories).toHaveLength(2);
+      expect(page1.total).toBe(5);
+
+      const page2 = repositoryService.list(db, { limit: 2, offset: 2 });
+      expect(page2.repositories).toHaveLength(2);
+      expect(page2.total).toBe(5);
+
+      const page3 = repositoryService.list(db, { limit: 2, offset: 4 });
+      expect(page3.repositories).toHaveLength(1);
+      expect(page3.total).toBe(5);
+    });
+
+    it('defaults to limit 20 offset 0', () => {
+      for (let i = 0; i < 25; i++) {
+        repositoryService.register(db, { path: `/repo-${i}` });
+      }
+
+      const result = repositoryService.list(db);
+      expect(result.repositories).toHaveLength(20);
+      expect(result.total).toBe(25);
+    });
+  });
+
+  describe('getByPath', () => {
+    it('returns repository when found', () => {
+      const created = repositoryService.register(db, { path: '/home/user/project' });
+      const found = repositoryService.getByPath(db, '/home/user/project');
+      expect(found).not.toBeNull();
+      expect(found?.id).toBe(created.id);
+    });
+
+    it('returns null when not found', () => {
+      const result = repositoryService.getByPath(db, '/nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('matches path exactly', () => {
+      repositoryService.register(db, { path: '/home/user/project' });
+      expect(repositoryService.getByPath(db, '/home/user/project/')).toBeNull();
+      expect(repositoryService.getByPath(db, '/home/user')).toBeNull();
+    });
+  });
+});

--- a/packages/core/src/services/repository.service.ts
+++ b/packages/core/src/services/repository.service.ts
@@ -1,0 +1,53 @@
+import type { DatabaseType } from '../db/connection';
+import type { Repository } from '../types/repository';
+import { repositoryId } from '../utils/id';
+
+export function register(db: DatabaseType, params: { path: string; name?: string }): Repository {
+  const existing = db.prepare('SELECT * FROM repositories WHERE path = ?').get(params.path) as
+    | Repository
+    | undefined;
+
+  if (existing) {
+    return existing;
+  }
+
+  const now = Date.now();
+  const repo: Repository = {
+    id: repositoryId(),
+    path: params.path,
+    name: params.name ?? null,
+    created_at: now,
+    updated_at: now,
+  };
+
+  db.prepare(
+    'INSERT INTO repositories (id, path, name, created_at, updated_at) VALUES (?, ?, ?, ?, ?)',
+  ).run(repo.id, repo.path, repo.name, repo.created_at, repo.updated_at);
+
+  return repo;
+}
+
+export function list(
+  db: DatabaseType,
+  params?: { limit?: number; offset?: number },
+): { repositories: Repository[]; total: number } {
+  const limit = params?.limit ?? 20;
+  const offset = params?.offset ?? 0;
+
+  const { total } = db.prepare('SELECT COUNT(*) as total FROM repositories').get() as {
+    total: number;
+  };
+
+  const repositories = db
+    .prepare('SELECT * FROM repositories ORDER BY created_at DESC LIMIT ? OFFSET ?')
+    .all(limit, offset) as Repository[];
+
+  return { repositories, total };
+}
+
+export function getByPath(db: DatabaseType, path: string): Repository | null {
+  const row = db.prepare('SELECT * FROM repositories WHERE path = ?').get(path) as
+    | Repository
+    | undefined;
+  return row ?? null;
+}

--- a/packages/core/src/services/transitions.ts
+++ b/packages/core/src/services/transitions.ts
@@ -1,0 +1,16 @@
+import type { WorkflowStatus } from '../types/workflow';
+
+export const WORKFLOW_TRANSITIONS: Record<WorkflowStatus, readonly WorkflowStatus[]> = {
+  planning: ['ready', 'abandoned'],
+  ready: ['in_progress', 'abandoned'],
+  in_progress: ['paused', 'completed', 'failed', 'abandoned'],
+  paused: ['in_progress', 'abandoned'],
+  failed: ['in_progress'],
+  completed: [],
+  abandoned: [],
+};
+
+export function isValidWorkflowTransition(from: WorkflowStatus, to: WorkflowStatus): boolean {
+  const allowed = WORKFLOW_TRANSITIONS[from];
+  return allowed.includes(to);
+}

--- a/packages/core/src/services/workflow.service.test.ts
+++ b/packages/core/src/services/workflow.service.test.ts
@@ -1,0 +1,641 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { DatabaseType } from '../db/connection';
+import { createConnection } from '../db/connection';
+import { runMigrations } from '../db/migrations';
+import type { Task } from '../types/task';
+import * as repositoryService from './repository.service';
+import * as workflowService from './workflow.service';
+
+function createBasicWorkflow(db: DatabaseType, overrides?: Partial<workflowService.CreateParams>) {
+  return workflowService.create(db, {
+    name: 'Test Workflow',
+    source_type: 'issue',
+    ...overrides,
+  });
+}
+
+describe('workflowService', () => {
+  let db: DatabaseType;
+
+  beforeEach(() => {
+    db = createConnection(':memory:');
+    runMigrations(db);
+  });
+
+  // --- create ---
+
+  describe('create', () => {
+    it('creates a workflow with required fields', () => {
+      const wf = createBasicWorkflow(db);
+      expect(wf.id).toMatch(/^wf_[0-9a-z]{12}$/);
+      expect(wf.name).toBe('Test Workflow');
+      expect(wf.source_type).toBe('issue');
+      expect(wf.status).toBe('planning');
+    });
+
+    it('defaults optional fields', () => {
+      const wf = createBasicWorkflow(db);
+      expect(wf.repository_id).toBeNull();
+      expect(wf.source_ref).toBeNull();
+      expect(wf.source_content).toBeNull();
+      expect(wf.initial_plan).toBeNull();
+      expect(wf.plan_summary).toBeNull();
+      expect(wf.max_parallel_tasks).toBe(1);
+      expect(wf.auto_create_workspaces).toBe(0);
+      expect(wf.config).toBeNull();
+    });
+
+    it('serializes config as JSON', () => {
+      const wf = createBasicWorkflow(db, {
+        config: { retries: 3, verbose: true },
+      });
+      expect(wf.config).toBe('{"retries":3,"verbose":true}');
+    });
+
+    it('sets source fields when provided', () => {
+      const wf = createBasicWorkflow(db, {
+        source_ref: 'issue-42',
+        source_content: 'Fix the bug',
+      });
+      expect(wf.source_ref).toBe('issue-42');
+      expect(wf.source_content).toBe('Fix the bug');
+    });
+
+    it('auto-registers repository from path', () => {
+      const wf = createBasicWorkflow(db, {
+        repository_path: '/home/user/project',
+      });
+      expect(wf.repository_id).toMatch(/^rp_[0-9a-z]{12}$/);
+
+      const repo = repositoryService.getByPath(db, '/home/user/project');
+      expect(repo).not.toBeNull();
+      expect(repo?.id).toBe(wf.repository_id);
+    });
+
+    it('uses provided repository_id over repository_path', () => {
+      const repo = repositoryService.register(db, { path: '/existing' });
+      const wf = createBasicWorkflow(db, { repository_id: repo.id });
+      expect(wf.repository_id).toBe(repo.id);
+    });
+
+    it('converts auto_create_workspaces boolean to 0/1', () => {
+      const wfTrue = createBasicWorkflow(db, { auto_create_workspaces: true });
+      expect(wfTrue.auto_create_workspaces).toBe(1);
+
+      const wfFalse = createBasicWorkflow(db, { auto_create_workspaces: false });
+      expect(wfFalse.auto_create_workspaces).toBe(0);
+    });
+
+    it('persists to database', () => {
+      const wf = createBasicWorkflow(db);
+      const fetched = workflowService.get(db, wf.id);
+      expect(fetched).not.toBeNull();
+      expect(fetched?.name).toBe('Test Workflow');
+    });
+  });
+
+  // --- get ---
+
+  describe('get', () => {
+    it('returns workflow when found', () => {
+      const wf = createBasicWorkflow(db);
+      const result = workflowService.get(db, wf.id);
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(wf.id);
+    });
+
+    it('returns null when not found', () => {
+      const result = workflowService.get(db, 'wf_nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('returns empty tasks array by default', () => {
+      const wf = createBasicWorkflow(db);
+      const result = workflowService.get(db, wf.id);
+      expect(result?.tasks).toEqual([]);
+    });
+
+    it('includes tasks when requested', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Test plan',
+        tasks: [{ name: 'Task A' }, { name: 'Task B' }],
+      });
+
+      const result = workflowService.get(db, wf.id, { includeTasks: true });
+      expect(result?.tasks).toHaveLength(2);
+    });
+
+    it('returns tasks ordered by sequence then name', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Test plan',
+        tasks: [{ name: 'Setup' }, { name: 'Build' }, { name: 'Deploy' }],
+      });
+
+      const result = workflowService.get(db, wf.id, { includeTasks: true });
+      expect(result?.tasks[0].name).toBe('Setup');
+      expect(result?.tasks[0].sequence).toBe(1);
+      expect(result?.tasks[1].name).toBe('Build');
+      expect(result?.tasks[1].sequence).toBe(2);
+      expect(result?.tasks[2].name).toBe('Deploy');
+      expect(result?.tasks[2].sequence).toBe(3);
+    });
+  });
+
+  // --- list ---
+
+  describe('list', () => {
+    it('returns empty list when no workflows', () => {
+      const result = workflowService.list(db);
+      expect(result.workflows).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('returns workflow summaries', () => {
+      createBasicWorkflow(db, { name: 'WF1' });
+      createBasicWorkflow(db, { name: 'WF2' });
+
+      const result = workflowService.list(db);
+      expect(result.workflows).toHaveLength(2);
+      expect(result.total).toBe(2);
+
+      // Summary fields only
+      const wf = result.workflows[0];
+      expect(wf).toHaveProperty('id');
+      expect(wf).toHaveProperty('name');
+      expect(wf).toHaveProperty('status');
+      expect(wf).toHaveProperty('created_at');
+      expect(wf).toHaveProperty('updated_at');
+    });
+
+    it('filters by repository_id', () => {
+      const repo = repositoryService.register(db, { path: '/project-a' });
+      createBasicWorkflow(db, { name: 'WF1', repository_id: repo.id });
+      createBasicWorkflow(db, { name: 'WF2' });
+
+      const result = workflowService.list(db, { repository_id: repo.id });
+      expect(result.workflows).toHaveLength(1);
+      expect(result.total).toBe(1);
+      expect(result.workflows[0].name).toBe('WF1');
+    });
+
+    it('filters by single status', () => {
+      const wf = createBasicWorkflow(db, { name: 'WF1' });
+      createBasicWorkflow(db, { name: 'WF2' });
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Plan',
+        tasks: [{ name: 'T1' }],
+      });
+
+      const result = workflowService.list(db, { status: 'ready' });
+      expect(result.workflows).toHaveLength(1);
+      expect(result.workflows[0].name).toBe('WF1');
+    });
+
+    it('filters by multiple statuses', () => {
+      const wf1 = createBasicWorkflow(db, { name: 'WF1' });
+      createBasicWorkflow(db, { name: 'WF2' });
+      workflowService.setPlan(db, wf1.id, {
+        summary: 'Plan',
+        tasks: [{ name: 'T1' }],
+      });
+
+      const result = workflowService.list(db, { status: ['planning', 'ready'] });
+      expect(result.workflows).toHaveLength(2);
+      expect(result.total).toBe(2);
+    });
+
+    it('combines filters', () => {
+      const repo = repositoryService.register(db, { path: '/project-a' });
+      const wf1 = createBasicWorkflow(db, { name: 'WF1', repository_id: repo.id });
+      createBasicWorkflow(db, { name: 'WF2', repository_id: repo.id });
+      createBasicWorkflow(db, { name: 'WF3' });
+
+      workflowService.setPlan(db, wf1.id, {
+        summary: 'Plan',
+        tasks: [{ name: 'T1' }],
+      });
+
+      const result = workflowService.list(db, {
+        repository_id: repo.id,
+        status: 'ready',
+      });
+      expect(result.workflows).toHaveLength(1);
+      expect(result.workflows[0].name).toBe('WF1');
+    });
+
+    it('paginates results', () => {
+      for (let i = 0; i < 5; i++) {
+        createBasicWorkflow(db, { name: `WF${i}` });
+      }
+
+      const page1 = workflowService.list(db, { limit: 2 });
+      expect(page1.workflows).toHaveLength(2);
+      expect(page1.total).toBe(5);
+
+      const page2 = workflowService.list(db, { limit: 2, offset: 2 });
+      expect(page2.workflows).toHaveLength(2);
+
+      const page3 = workflowService.list(db, { limit: 2, offset: 4 });
+      expect(page3.workflows).toHaveLength(1);
+    });
+
+    it('returns correct total with filters', () => {
+      createBasicWorkflow(db, { name: 'WF1' });
+      createBasicWorkflow(db, { name: 'WF2' });
+      createBasicWorkflow(db, { name: 'WF3' });
+
+      const result = workflowService.list(db, { status: 'planning', limit: 1 });
+      expect(result.workflows).toHaveLength(1);
+      expect(result.total).toBe(3);
+    });
+  });
+
+  // --- setPlan ---
+
+  describe('setPlan', () => {
+    it('sets plan and transitions to ready', () => {
+      const wf = createBasicWorkflow(db);
+      const result = workflowService.setPlan(db, wf.id, {
+        summary: 'Build the feature',
+        tasks: [
+          { name: 'Setup', description: 'Initial setup' },
+          { name: 'Implement', description: 'Core implementation' },
+        ],
+      });
+
+      expect(result.workflow_id).toBe(wf.id);
+      expect(result.tasks_created).toBe(2);
+      expect(result.status).toBe('ready');
+
+      const updated = workflowService.get(db, wf.id);
+      expect(updated?.status).toBe('ready');
+      expect(updated?.plan_summary).toBe('Build the feature');
+      expect(updated?.initial_plan).not.toBeNull();
+    });
+
+    it('creates tasks with correct sequences', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Plan',
+        tasks: [{ name: 'First' }, { name: 'Second' }, { name: 'Third' }],
+      });
+
+      const result = workflowService.get(db, wf.id, { includeTasks: true });
+      expect(result?.tasks[0].sequence).toBe(1);
+      expect(result?.tasks[1].sequence).toBe(2);
+      expect(result?.tasks[2].sequence).toBe(3);
+    });
+
+    it('creates task dependencies', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Plan',
+        tasks: [
+          { name: 'Setup' },
+          { name: 'Build', depends_on: ['Setup'] },
+          { name: 'Test', depends_on: ['Build'] },
+        ],
+      });
+
+      const wfResult = workflowService.get(db, wf.id, { includeTasks: true });
+      const tasks = wfResult?.tasks ?? [];
+      const buildId = tasks.find((t) => t.name === 'Build')?.id;
+      const setupId = tasks.find((t) => t.name === 'Setup')?.id;
+
+      const deps = db.prepare('SELECT * FROM task_dependencies WHERE task_id = ?').all(buildId) as {
+        task_id: string;
+        depends_on_id: string;
+        dependency_type: string;
+      }[];
+      expect(deps).toHaveLength(1);
+      expect(deps[0].depends_on_id).toBe(setupId);
+      expect(deps[0].dependency_type).toBe('blocks');
+    });
+
+    it('tracks parallel groups', () => {
+      const wf = createBasicWorkflow(db);
+      const result = workflowService.setPlan(db, wf.id, {
+        summary: 'Plan',
+        tasks: [
+          { name: 'A', parallel_group: 'group-1' },
+          { name: 'B', parallel_group: 'group-1' },
+          { name: 'C', parallel_group: 'group-2' },
+          { name: 'D' },
+        ],
+      });
+
+      expect(result.parallelizable_groups).toHaveLength(2);
+      expect(result.parallelizable_groups).toContain('group-1');
+      expect(result.parallelizable_groups).toContain('group-2');
+    });
+
+    it('stores estimated_complexity and files_likely_affected in context', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Plan',
+        tasks: [
+          {
+            name: 'Task',
+            estimated_complexity: 'high',
+            files_likely_affected: ['src/main.ts', 'src/utils.ts'],
+          },
+        ],
+      });
+
+      const result = workflowService.get(db, wf.id, { includeTasks: true });
+      const context = JSON.parse(result?.tasks[0].context as string);
+      expect(context.estimated_complexity).toBe('high');
+      expect(context.files_likely_affected).toEqual(['src/main.ts', 'src/utils.ts']);
+    });
+
+    it('throws when workflow not found', () => {
+      expect(() => {
+        workflowService.setPlan(db, 'wf_nonexistent', {
+          summary: 'Plan',
+          tasks: [],
+        });
+      }).toThrow('Workflow not found');
+    });
+
+    it('throws when workflow is not in planning status', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Plan',
+        tasks: [{ name: 'T1' }],
+      });
+
+      // Now workflow is 'ready'
+      expect(() => {
+        workflowService.setPlan(db, wf.id, {
+          summary: 'New plan',
+          tasks: [{ name: 'T2' }],
+        });
+      }).toThrow("Cannot set plan: workflow status is 'ready', expected 'planning'");
+    });
+
+    it('throws on unknown dependency name', () => {
+      const wf = createBasicWorkflow(db);
+      expect(() => {
+        workflowService.setPlan(db, wf.id, {
+          summary: 'Plan',
+          tasks: [{ name: 'Build', depends_on: ['Nonexistent'] }],
+        });
+      }).toThrow("Unknown dependency 'Nonexistent' in task 'Build'");
+    });
+
+    it('is atomic — rolls back on dependency error', () => {
+      const wf = createBasicWorkflow(db);
+      try {
+        workflowService.setPlan(db, wf.id, {
+          summary: 'Plan',
+          tasks: [{ name: 'Setup' }, { name: 'Build', depends_on: ['Missing'] }],
+        });
+      } catch {
+        // expected
+      }
+
+      // Workflow should still be in planning
+      const fetched = workflowService.get(db, wf.id);
+      expect(fetched?.status).toBe('planning');
+
+      // No tasks should have been created
+      const tasks = db.prepare('SELECT * FROM tasks WHERE workflow_id = ?').all(wf.id) as Task[];
+      expect(tasks).toHaveLength(0);
+    });
+
+    it('handles empty task list', () => {
+      const wf = createBasicWorkflow(db);
+      const result = workflowService.setPlan(db, wf.id, {
+        summary: 'No tasks',
+        tasks: [],
+      });
+
+      expect(result.tasks_created).toBe(0);
+      expect(result.parallelizable_groups).toEqual([]);
+
+      const updated = workflowService.get(db, wf.id);
+      expect(updated?.status).toBe('ready');
+    });
+  });
+
+  // --- updateStatus ---
+
+  describe('updateStatus', () => {
+    it('transitions planning → abandoned', () => {
+      const wf = createBasicWorkflow(db);
+      const updated = workflowService.updateStatus(db, wf.id, 'abandoned');
+      expect(updated.status).toBe('abandoned');
+    });
+
+    it('transitions ready → in_progress', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      const updated = workflowService.updateStatus(db, wf.id, 'in_progress');
+      expect(updated.status).toBe('in_progress');
+    });
+
+    it('transitions in_progress → paused', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      const updated = workflowService.updateStatus(db, wf.id, 'paused');
+      expect(updated.status).toBe('paused');
+    });
+
+    it('transitions in_progress → completed', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      const updated = workflowService.updateStatus(db, wf.id, 'completed');
+      expect(updated.status).toBe('completed');
+    });
+
+    it('transitions in_progress → failed', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      const updated = workflowService.updateStatus(db, wf.id, 'failed');
+      expect(updated.status).toBe('failed');
+    });
+
+    it('transitions failed → in_progress (retry)', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      workflowService.updateStatus(db, wf.id, 'failed');
+      const updated = workflowService.updateStatus(db, wf.id, 'in_progress');
+      expect(updated.status).toBe('in_progress');
+    });
+
+    it('transitions paused → in_progress (resume)', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      workflowService.updateStatus(db, wf.id, 'paused');
+      const updated = workflowService.updateStatus(db, wf.id, 'in_progress');
+      expect(updated.status).toBe('in_progress');
+    });
+
+    it('rejects invalid transitions from completed', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      workflowService.updateStatus(db, wf.id, 'completed');
+      expect(() => workflowService.updateStatus(db, wf.id, 'in_progress')).toThrow(
+        'Invalid transition',
+      );
+    });
+
+    it('rejects invalid transitions from abandoned', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.updateStatus(db, wf.id, 'abandoned');
+      expect(() => workflowService.updateStatus(db, wf.id, 'in_progress')).toThrow(
+        'Invalid transition',
+      );
+    });
+
+    it('rejects invalid transition from planning to completed', () => {
+      const wf = createBasicWorkflow(db);
+      expect(() => workflowService.updateStatus(db, wf.id, 'completed')).toThrow(
+        'Invalid transition',
+      );
+    });
+
+    it('stores reason in config', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      const updated = workflowService.updateStatus(db, wf.id, 'paused', 'Waiting for review');
+
+      const config = JSON.parse(updated.config as string);
+      expect(config.last_status_reason).toBe('Waiting for review');
+    });
+
+    it('preserves existing config when adding reason', () => {
+      const wf = createBasicWorkflow(db, { config: { retries: 3 } });
+      workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'T1' }] });
+      workflowService.updateStatus(db, wf.id, 'in_progress');
+      const updated = workflowService.updateStatus(db, wf.id, 'paused', 'Waiting');
+
+      const config = JSON.parse(updated.config as string);
+      expect(config.retries).toBe(3);
+      expect(config.last_status_reason).toBe('Waiting');
+    });
+
+    it('throws when workflow not found', () => {
+      expect(() => workflowService.updateStatus(db, 'wf_nonexistent', 'ready')).toThrow(
+        'Workflow not found',
+      );
+    });
+
+    it('updates the updated_at timestamp', () => {
+      const wf = createBasicWorkflow(db);
+      const updated = workflowService.updateStatus(db, wf.id, 'abandoned');
+      expect(updated.updated_at).toBeGreaterThanOrEqual(wf.updated_at);
+    });
+  });
+
+  // --- setParallelism ---
+
+  describe('setParallelism', () => {
+    it('updates max_parallel_tasks', () => {
+      const wf = createBasicWorkflow(db);
+      const updated = workflowService.setParallelism(db, wf.id, 4);
+      expect(updated.max_parallel_tasks).toBe(4);
+    });
+
+    it('conditionally updates auto_create_workspaces', () => {
+      const wf = createBasicWorkflow(db);
+      const updated = workflowService.setParallelism(db, wf.id, 2, true);
+      expect(updated.auto_create_workspaces).toBe(1);
+
+      const updated2 = workflowService.setParallelism(db, wf.id, 3, false);
+      expect(updated2.auto_create_workspaces).toBe(0);
+    });
+
+    it('does not change auto_create_workspaces when not provided', () => {
+      const wf = createBasicWorkflow(db, { auto_create_workspaces: true });
+      const updated = workflowService.setParallelism(db, wf.id, 4);
+      expect(updated.auto_create_workspaces).toBe(1);
+    });
+
+    it('throws when workflow not found', () => {
+      expect(() => workflowService.setParallelism(db, 'wf_nonexistent', 2)).toThrow(
+        'Workflow not found',
+      );
+    });
+
+    it('persists changes to database', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setParallelism(db, wf.id, 5, true);
+      const fetched = workflowService.get(db, wf.id);
+      expect(fetched?.max_parallel_tasks).toBe(5);
+      expect(fetched?.auto_create_workspaces).toBe(1);
+    });
+  });
+
+  // --- getSummary ---
+
+  describe('getSummary', () => {
+    it('returns JSON format summary', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Build feature X',
+        tasks: [{ name: 'Setup' }, { name: 'Build' }],
+      });
+
+      const result = workflowService.getSummary(db, wf.id, 'json');
+      const parsed = JSON.parse(result.summary);
+      expect(parsed.name).toBe('Test Workflow');
+      expect(parsed.status).toBe('ready');
+      expect(parsed.total_tasks).toBe(2);
+      expect(parsed.plan_summary).toBe('Build feature X');
+      expect(parsed.tasks_by_status.pending).toBe(2);
+    });
+
+    it('returns markdown format summary', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Build feature X',
+        tasks: [{ name: 'Setup' }],
+      });
+
+      const result = workflowService.getSummary(db, wf.id, 'markdown');
+      expect(result.summary).toContain('# Test Workflow');
+      expect(result.summary).toContain('**Status:** ready');
+      expect(result.summary).toContain('**Tasks:** 1 total');
+      expect(result.summary).toContain('Build feature X');
+      expect(result.summary).toContain('- pending: 1');
+    });
+
+    it('estimates token count', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, {
+        summary: 'Plan',
+        tasks: [{ name: 'T1' }],
+      });
+
+      const result = workflowService.getSummary(db, wf.id, 'json');
+      expect(result.token_estimate).toBe(Math.ceil(result.summary.length / 4));
+      expect(result.token_estimate).toBeGreaterThan(0);
+    });
+
+    it('throws when workflow not found', () => {
+      expect(() => workflowService.getSummary(db, 'wf_nonexistent', 'json')).toThrow(
+        'Workflow not found',
+      );
+    });
+
+    it('handles workflow with no tasks', () => {
+      const wf = createBasicWorkflow(db);
+      workflowService.setPlan(db, wf.id, { summary: 'Empty', tasks: [] });
+
+      const result = workflowService.getSummary(db, wf.id, 'json');
+      const parsed = JSON.parse(result.summary);
+      expect(parsed.total_tasks).toBe(0);
+      expect(parsed.tasks_by_status).toEqual({});
+    });
+  });
+});

--- a/packages/core/src/services/workflow.service.ts
+++ b/packages/core/src/services/workflow.service.ts
@@ -1,0 +1,395 @@
+import type { DatabaseType } from '../db/connection';
+import type { Task } from '../types/task';
+import type { Workflow, WorkflowStatus, WorkflowSummary } from '../types/workflow';
+import { taskId, workflowId } from '../utils/id';
+import * as repositoryService from './repository.service';
+import { isValidWorkflowTransition } from './transitions';
+
+// --- Parameter / Result types ---
+
+export interface CreateParams {
+  name: string;
+  source_type: string;
+  source_ref?: string;
+  source_content?: string;
+  repository_id?: string;
+  repository_path?: string;
+  max_parallel_tasks?: number;
+  auto_create_workspaces?: boolean;
+  config?: Record<string, unknown>;
+}
+
+export interface GetOptions {
+  includeTasks?: boolean;
+}
+
+export interface WorkflowWithTasks extends Workflow {
+  tasks: Task[];
+}
+
+export interface ListFilters {
+  repository_id?: string;
+  status?: WorkflowStatus | WorkflowStatus[];
+  limit?: number;
+  offset?: number;
+}
+
+export interface PlanTask {
+  name: string;
+  description?: string;
+  parallel_group?: string;
+  estimated_complexity?: string;
+  files_likely_affected?: string[];
+  depends_on?: string[];
+}
+
+export interface SetPlanParams {
+  summary: string;
+  tasks: PlanTask[];
+}
+
+export interface SetPlanResult {
+  workflow_id: string;
+  tasks_created: number;
+  parallelizable_groups: string[];
+  status: 'ready';
+}
+
+// --- Service functions ---
+
+export function create(db: DatabaseType, params: CreateParams): Workflow {
+  let repoId = params.repository_id ?? null;
+
+  if (!repoId && params.repository_path) {
+    const repo = repositoryService.register(db, { path: params.repository_path });
+    repoId = repo.id;
+  }
+
+  const now = Date.now();
+  const configJson = params.config ? JSON.stringify(params.config) : null;
+
+  const workflow: Workflow = {
+    id: workflowId(),
+    repository_id: repoId,
+    name: params.name,
+    source_type: params.source_type,
+    source_ref: params.source_ref ?? null,
+    source_content: params.source_content ?? null,
+    status: 'planning',
+    initial_plan: null,
+    plan_summary: null,
+    created_at: now,
+    updated_at: now,
+    max_parallel_tasks: params.max_parallel_tasks ?? 1,
+    auto_create_workspaces: params.auto_create_workspaces ? 1 : 0,
+    config: configJson,
+  };
+
+  db.prepare(
+    `INSERT INTO workflows
+      (id, repository_id, name, source_type, source_ref, source_content, status,
+       initial_plan, plan_summary, created_at, updated_at, max_parallel_tasks,
+       auto_create_workspaces, config)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    workflow.id,
+    workflow.repository_id,
+    workflow.name,
+    workflow.source_type,
+    workflow.source_ref,
+    workflow.source_content,
+    workflow.status,
+    workflow.initial_plan,
+    workflow.plan_summary,
+    workflow.created_at,
+    workflow.updated_at,
+    workflow.max_parallel_tasks,
+    workflow.auto_create_workspaces,
+    workflow.config,
+  );
+
+  return workflow;
+}
+
+export function get(db: DatabaseType, id: string, options?: GetOptions): WorkflowWithTasks | null {
+  const row = db.prepare('SELECT * FROM workflows WHERE id = ?').get(id) as Workflow | undefined;
+
+  if (!row) {
+    return null;
+  }
+
+  const tasks: Task[] = options?.includeTasks
+    ? (db
+        .prepare('SELECT * FROM tasks WHERE workflow_id = ? ORDER BY sequence, name')
+        .all(id) as Task[])
+    : [];
+
+  return { ...row, tasks };
+}
+
+export function list(
+  db: DatabaseType,
+  filters?: ListFilters,
+): { workflows: WorkflowSummary[]; total: number } {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  const limit = filters?.limit ?? 20;
+  const offset = filters?.offset ?? 0;
+
+  if (filters?.repository_id) {
+    conditions.push('repository_id = ?');
+    params.push(filters.repository_id);
+  }
+
+  if (filters?.status) {
+    const statuses = Array.isArray(filters.status) ? filters.status : [filters.status];
+    conditions.push(`status IN (${statuses.map(() => '?').join(', ')})`);
+    params.push(...statuses);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const { total } = db
+    .prepare(`SELECT COUNT(*) as total FROM workflows ${where}`)
+    .get(...params) as {
+    total: number;
+  };
+
+  const workflows = db
+    .prepare(
+      `SELECT id, name, status, created_at, updated_at FROM workflows ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`,
+    )
+    .all(...params, limit, offset) as WorkflowSummary[];
+
+  return { workflows, total };
+}
+
+export function setPlan(db: DatabaseType, id: string, plan: SetPlanParams): SetPlanResult {
+  const run = db.transaction(() => {
+    const workflow = db.prepare('SELECT * FROM workflows WHERE id = ?').get(id) as
+      | Workflow
+      | undefined;
+
+    if (!workflow) {
+      throw new Error(`Workflow not found: ${id}`);
+    }
+
+    if (workflow.status !== 'planning') {
+      throw new Error(
+        `Cannot set plan: workflow status is '${workflow.status}', expected 'planning'`,
+      );
+    }
+
+    const now = Date.now();
+    const planJson = JSON.stringify(plan);
+
+    db.prepare(
+      'UPDATE workflows SET initial_plan = ?, plan_summary = ?, status = ?, updated_at = ? WHERE id = ?',
+    ).run(planJson, plan.summary, 'ready', now, id);
+
+    // First pass: insert all tasks, build name→id map
+    const nameToIdMap = new Map<string, string>();
+    const parallelGroups = new Set<string>();
+
+    const insertTask = db.prepare(
+      `INSERT INTO tasks
+        (id, workflow_id, name, description, status, sequence, parallel_group, context, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+
+    for (let i = 0; i < plan.tasks.length; i++) {
+      const t = plan.tasks[i];
+      const tId = taskId();
+      nameToIdMap.set(t.name, tId);
+
+      if (t.parallel_group) {
+        parallelGroups.add(t.parallel_group);
+      }
+
+      const context: Record<string, unknown> = {};
+      if (t.estimated_complexity) context.estimated_complexity = t.estimated_complexity;
+      if (t.files_likely_affected) context.files_likely_affected = t.files_likely_affected;
+      const contextJson = Object.keys(context).length > 0 ? JSON.stringify(context) : null;
+
+      insertTask.run(
+        tId,
+        id,
+        t.name,
+        t.description ?? null,
+        'pending',
+        i + 1,
+        t.parallel_group ?? null,
+        contextJson,
+        now,
+        now,
+      );
+    }
+
+    // Second pass: insert task dependencies
+    const insertDep = db.prepare(
+      'INSERT INTO task_dependencies (task_id, depends_on_id, dependency_type) VALUES (?, ?, ?)',
+    );
+
+    for (const t of plan.tasks) {
+      if (!t.depends_on || t.depends_on.length === 0) continue;
+
+      const tId = nameToIdMap.get(t.name) as string;
+      for (const depName of t.depends_on) {
+        const depId = nameToIdMap.get(depName);
+        if (!depId) {
+          throw new Error(`Unknown dependency '${depName}' in task '${t.name}'`);
+        }
+        insertDep.run(tId, depId, 'blocks');
+      }
+    }
+
+    return {
+      workflow_id: id,
+      tasks_created: plan.tasks.length,
+      parallelizable_groups: [...parallelGroups],
+      status: 'ready' as const,
+    };
+  });
+
+  return run();
+}
+
+export function updateStatus(
+  db: DatabaseType,
+  id: string,
+  status: WorkflowStatus,
+  reason?: string,
+): Workflow {
+  const workflow = db.prepare('SELECT * FROM workflows WHERE id = ?').get(id) as
+    | Workflow
+    | undefined;
+
+  if (!workflow) {
+    throw new Error(`Workflow not found: ${id}`);
+  }
+
+  if (!isValidWorkflowTransition(workflow.status, status)) {
+    throw new Error(`Invalid transition from '${workflow.status}' to '${status}'`);
+  }
+
+  const now = Date.now();
+  let config = workflow.config ? JSON.parse(workflow.config) : {};
+
+  if (reason) {
+    config = { ...config, last_status_reason: reason };
+  }
+
+  const configJson = Object.keys(config).length > 0 ? JSON.stringify(config) : workflow.config;
+
+  db.prepare('UPDATE workflows SET status = ?, updated_at = ?, config = ? WHERE id = ?').run(
+    status,
+    now,
+    configJson,
+    id,
+  );
+
+  return { ...workflow, status, updated_at: now, config: configJson };
+}
+
+export function setParallelism(
+  db: DatabaseType,
+  id: string,
+  maxParallel: number,
+  autoCreateWorkspaces?: boolean,
+): Workflow {
+  const workflow = db.prepare('SELECT * FROM workflows WHERE id = ?').get(id) as
+    | Workflow
+    | undefined;
+
+  if (!workflow) {
+    throw new Error(`Workflow not found: ${id}`);
+  }
+
+  const now = Date.now();
+  const updates: string[] = ['max_parallel_tasks = ?', 'updated_at = ?'];
+  const params: unknown[] = [maxParallel, now];
+
+  if (autoCreateWorkspaces !== undefined) {
+    updates.push('auto_create_workspaces = ?');
+    params.push(autoCreateWorkspaces ? 1 : 0);
+  }
+
+  params.push(id);
+  db.prepare(`UPDATE workflows SET ${updates.join(', ')} WHERE id = ?`).run(...params);
+
+  return {
+    ...workflow,
+    max_parallel_tasks: maxParallel,
+    auto_create_workspaces:
+      autoCreateWorkspaces !== undefined
+        ? autoCreateWorkspaces
+          ? 1
+          : 0
+        : workflow.auto_create_workspaces,
+    updated_at: now,
+  };
+}
+
+export function getSummary(
+  db: DatabaseType,
+  id: string,
+  format: 'json' | 'markdown',
+): { summary: string; token_estimate: number } {
+  const workflow = db.prepare('SELECT * FROM workflows WHERE id = ?').get(id) as
+    | Workflow
+    | undefined;
+
+  if (!workflow) {
+    throw new Error(`Workflow not found: ${id}`);
+  }
+
+  const tasks = db
+    .prepare('SELECT * FROM tasks WHERE workflow_id = ? ORDER BY sequence, name')
+    .all(id) as Task[];
+
+  const taskCountsByStatus: Record<string, number> = {};
+  for (const t of tasks) {
+    taskCountsByStatus[t.status] = (taskCountsByStatus[t.status] ?? 0) + 1;
+  }
+
+  let summary: string;
+
+  if (format === 'json') {
+    const obj = {
+      id: workflow.id,
+      name: workflow.name,
+      status: workflow.status,
+      plan_summary: workflow.plan_summary,
+      total_tasks: tasks.length,
+      tasks_by_status: taskCountsByStatus,
+    };
+    summary = JSON.stringify(obj, null, 2);
+  } else {
+    const lines: string[] = [
+      `# ${workflow.name}`,
+      '',
+      `**Status:** ${workflow.status}`,
+      `**Tasks:** ${tasks.length} total`,
+      '',
+    ];
+
+    if (workflow.plan_summary) {
+      lines.push(`## Plan`, '', workflow.plan_summary, '');
+    }
+
+    if (Object.keys(taskCountsByStatus).length > 0) {
+      lines.push('## Tasks by Status', '');
+      for (const [status, count] of Object.entries(taskCountsByStatus)) {
+        lines.push(`- ${status}: ${count}`);
+      }
+      lines.push('');
+    }
+
+    summary = lines.join('\n');
+  }
+
+  return {
+    summary,
+    token_estimate: Math.ceil(summary.length / 4),
+  };
+}


### PR DESCRIPTION
Closes #6
Closes #14

## Summary

- Add **workflow service** with `create`, `get`, `list`, `setPlan` (transactional with task/dependency creation), `updateStatus` (state machine validated), `setParallelism`, and `getSummary` (JSON + markdown formats)
- Add **repository service** with `register` (idempotent upsert), `list` (paginated), and `getByPath`
- Add **workflow state machine** (`WORKFLOW_TRANSITIONS` map + `isValidWorkflowTransition()`) covering all valid transitions including terminal states (`completed`, `abandoned`)
- Export services, transition utilities, and param/result types from `@caw/core` barrel

## Testing

- [x] Tests added/updated (67 new tests, 87 total)
- [x] All tests passing (`pnpm --filter @caw/core test`)
- [x] Type checking clean (`tsc --noEmit`)
- [x] Lint clean (`biome check`)
- [x] Build clean (`tsup`)