### PR TITLE
feat: workflow MCP tools

### DIFF
--- a/packages/mcp-server/src/tools/context.ts
+++ b/packages/mcp-server/src/tools/context.ts
@@ -1,4 +1,4 @@
-import { contextService, workflowService } from '@caw/core';
+import { contextService } from '@caw/core';
 import { z } from 'zod';
 import type { ToolRegistrar } from './types';
 import { defineTool, handleToolCall } from './types';
@@ -64,22 +64,6 @@ export const register: ToolRegistrar = (server, db) => {
             : undefined,
           max_tokens: args.max_tokens,
         });
-      }),
-  );
-
-  defineTool(
-    server,
-    'workflow_get_summary',
-    {
-      description: 'Get compressed workflow summary for quick status checks',
-      inputSchema: {
-        id: z.string().describe('Workflow ID'),
-        format: z.enum(['json', 'markdown']).optional().describe('Output format, default json'),
-      },
-    },
-    (args) =>
-      handleToolCall(() => {
-        return workflowService.getSummary(db, args.id, args.format ?? 'json');
       }),
   );
 };

--- a/packages/mcp-server/src/tools/types.ts
+++ b/packages/mcp-server/src/tools/types.ts
@@ -5,6 +5,36 @@ import type { ZodTypeAny } from 'zod';
 
 export type ToolRegistrar = (server: McpServer, db: DatabaseType) => void;
 
+export interface ToolErrorInfo {
+  code: string;
+  message: string;
+  recoverable: boolean;
+  suggestion: string;
+}
+
+export class ToolCallError extends Error {
+  readonly code: string;
+  readonly recoverable: boolean;
+  readonly suggestion: string;
+
+  constructor(info: ToolErrorInfo) {
+    super(info.message);
+    this.name = 'ToolCallError';
+    this.code = info.code;
+    this.recoverable = info.recoverable;
+    this.suggestion = info.suggestion;
+  }
+
+  toJSON(): ToolErrorInfo {
+    return {
+      code: this.code,
+      message: this.message,
+      recoverable: this.recoverable,
+      suggestion: this.suggestion,
+    };
+  }
+}
+
 /**
  * Registers a tool on the MCP server, bypassing deep Zod generic inference
  * that causes tsc to hang with complex nested schemas across 43 tools.
@@ -39,6 +69,12 @@ export function handleToolCall<T>(fn: () => T): CallToolResult {
     const result = fn();
     return toolResult(result);
   } catch (err: unknown) {
+    if (err instanceof ToolCallError) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify(err.toJSON(), null, 2) }],
+        isError: true,
+      };
+    }
     const message = err instanceof Error ? err.message : String(err);
     return toolError(message);
   }

--- a/packages/mcp-server/src/tools/workflow.test.ts
+++ b/packages/mcp-server/src/tools/workflow.test.ts
@@ -1,0 +1,469 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import type { DatabaseType } from '@caw/core';
+import { createConnection, runMigrations, workflowService } from '@caw/core';
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { createMcpServer } from '../server';
+import type { ToolErrorInfo } from './types';
+
+type ToolHandler = (args: Record<string, unknown>) => CallToolResult | Promise<CallToolResult>;
+
+function getToolHandler(server: unknown, name: string): ToolHandler {
+  // biome-ignore lint/suspicious/noExplicitAny: accessing private for test
+  const tools = (server as any)._registeredTools as Record<string, { handler: ToolHandler }>;
+  return tools[name].handler;
+}
+
+function parseContent(result: CallToolResult): unknown {
+  const text = result.content[0];
+  if (text.type !== 'text') throw new Error('Expected text content');
+  return JSON.parse(text.text);
+}
+
+function parseError(result: CallToolResult): ToolErrorInfo {
+  expect(result.isError).toBe(true);
+  return parseContent(result) as ToolErrorInfo;
+}
+
+describe('workflow tools', () => {
+  let db: DatabaseType;
+  let call: (name: string, args: Record<string, unknown>) => CallToolResult;
+
+  beforeEach(() => {
+    db = createConnection(':memory:');
+    runMigrations(db);
+    const server = createMcpServer(db);
+    call = (name, args) => {
+      const handler = getToolHandler(server, name);
+      return handler(args) as CallToolResult;
+    };
+  });
+
+  // --- workflow_create ---
+
+  describe('workflow_create', () => {
+    it('creates a workflow and returns expected shape', () => {
+      const result = call('workflow_create', {
+        name: 'Test Workflow',
+        source_type: 'prompt',
+        source_content: 'Build something',
+      });
+
+      expect(result.isError).toBeUndefined();
+      const data = parseContent(result) as {
+        id: string;
+        name: string;
+        status: string;
+        max_parallel_tasks: number;
+      };
+      expect(data.id).toMatch(/^wf_/);
+      expect(data.name).toBe('Test Workflow');
+      expect(data.status).toBe('planning');
+      expect(data.max_parallel_tasks).toBe(1);
+    });
+
+    it('accepts optional parallelism settings', () => {
+      const result = call('workflow_create', {
+        name: 'Parallel Workflow',
+        source_type: 'prompt',
+        source_content: 'Build in parallel',
+        max_parallel_tasks: 3,
+        auto_create_workspaces: true,
+      });
+
+      const data = parseContent(result) as { max_parallel_tasks: number };
+      expect(data.max_parallel_tasks).toBe(3);
+    });
+  });
+
+  // --- workflow_get ---
+
+  describe('workflow_get', () => {
+    it('returns workflow details', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'Fetch Me',
+          source_type: 'prompt',
+          source_content: 'content',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_get', { id: created.id });
+      expect(result.isError).toBeUndefined();
+      const data = parseContent(result) as { id: string; name: string };
+      expect(data.id).toBe(created.id);
+      expect(data.name).toBe('Fetch Me');
+    });
+
+    it('returns structured error for missing workflow', () => {
+      const result = call('workflow_get', { id: 'wf_nonexistent' });
+      const err = parseError(result);
+      expect(err.code).toBe('WORKFLOW_NOT_FOUND');
+      expect(err.recoverable).toBe(false);
+      expect(err.suggestion).toContain('Check the workflow ID');
+    });
+  });
+
+  // --- workflow_list ---
+
+  describe('workflow_list', () => {
+    it('returns empty list when no workflows', () => {
+      const result = call('workflow_list', {});
+      const data = parseContent(result) as { workflows: unknown[]; total: number };
+      expect(data.workflows).toEqual([]);
+      expect(data.total).toBe(0);
+    });
+
+    it('returns created workflows', () => {
+      call('workflow_create', {
+        name: 'WF 1',
+        source_type: 'prompt',
+        source_content: 'a',
+      });
+      call('workflow_create', {
+        name: 'WF 2',
+        source_type: 'prompt',
+        source_content: 'b',
+      });
+
+      const result = call('workflow_list', {});
+      const data = parseContent(result) as { workflows: unknown[]; total: number };
+      expect(data.total).toBe(2);
+      expect(data.workflows).toHaveLength(2);
+    });
+
+    it('filters by status', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      // Move to ready by setting a plan
+      workflowService.setPlan(db, created.id, {
+        summary: 'plan',
+        tasks: [{ name: 'task1' }],
+      });
+
+      const planningOnly = call('workflow_list', { status: ['planning'] });
+      const planningData = parseContent(planningOnly) as { total: number };
+      expect(planningData.total).toBe(0);
+
+      const readyOnly = call('workflow_list', { status: ['ready'] });
+      const readyData = parseContent(readyOnly) as { total: number };
+      expect(readyData.total).toBe(1);
+    });
+  });
+
+  // --- workflow_set_plan ---
+
+  describe('workflow_set_plan', () => {
+    it('creates tasks from plan', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'Planned WF',
+          source_type: 'prompt',
+          source_content: 'content',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_set_plan', {
+        id: created.id,
+        plan: {
+          summary: 'Build the feature',
+          tasks: [
+            { name: 'Setup', description: 'Initial setup' },
+            { name: 'Implement', depends_on: ['Setup'] },
+            { name: 'Test', depends_on: ['Implement'] },
+          ],
+        },
+      });
+
+      expect(result.isError).toBeUndefined();
+      const data = parseContent(result) as {
+        workflow_id: string;
+        tasks_created: number;
+        status: string;
+      };
+      expect(data.workflow_id).toBe(created.id);
+      expect(data.tasks_created).toBe(3);
+      expect(data.status).toBe('ready');
+    });
+
+    it('returns WORKFLOW_NOT_FOUND for missing workflow', () => {
+      const result = call('workflow_set_plan', {
+        id: 'wf_nonexistent',
+        plan: { summary: 'x', tasks: [] },
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('WORKFLOW_NOT_FOUND');
+    });
+
+    it('returns INVALID_STATE when workflow is not in planning status', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      // Set plan to move to 'ready'
+      call('workflow_set_plan', {
+        id: created.id,
+        plan: { summary: 'plan', tasks: [{ name: 'task1' }] },
+      });
+
+      // Try to set plan again
+      const result = call('workflow_set_plan', {
+        id: created.id,
+        plan: { summary: 'plan2', tasks: [{ name: 'task2' }] },
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('INVALID_STATE');
+      expect(err.recoverable).toBe(false);
+    });
+
+    it('returns DUPLICATE_TASK_NAME for duplicate names', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_set_plan', {
+        id: created.id,
+        plan: {
+          summary: 'plan',
+          tasks: [{ name: 'dup' }, { name: 'dup' }],
+        },
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('DUPLICATE_TASK_NAME');
+      expect(err.recoverable).toBe(true);
+    });
+
+    it('returns SELF_DEPENDENCY for self-referencing tasks', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_set_plan', {
+        id: created.id,
+        plan: {
+          summary: 'plan',
+          tasks: [{ name: 'circular', depends_on: ['circular'] }],
+        },
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('SELF_DEPENDENCY');
+      expect(err.recoverable).toBe(true);
+    });
+
+    it('returns UNKNOWN_DEPENDENCY for invalid dependency references', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_set_plan', {
+        id: created.id,
+        plan: {
+          summary: 'plan',
+          tasks: [{ name: 'task1', depends_on: ['nonexistent'] }],
+        },
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('UNKNOWN_DEPENDENCY');
+      expect(err.recoverable).toBe(true);
+    });
+  });
+
+  // --- workflow_update_status ---
+
+  describe('workflow_update_status', () => {
+    it('updates status with valid transition', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      // planning → ready via set_plan
+      call('workflow_set_plan', {
+        id: created.id,
+        plan: { summary: 'plan', tasks: [{ name: 'task1' }] },
+      });
+
+      // ready → in_progress
+      const result = call('workflow_update_status', {
+        id: created.id,
+        status: 'in_progress',
+      });
+      expect(result.isError).toBeUndefined();
+      const data = parseContent(result) as { success: boolean };
+      expect(data.success).toBe(true);
+    });
+
+    it('returns WORKFLOW_NOT_FOUND for missing workflow', () => {
+      const result = call('workflow_update_status', {
+        id: 'wf_nonexistent',
+        status: 'in_progress',
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('WORKFLOW_NOT_FOUND');
+    });
+
+    it('returns INVALID_TRANSITION for invalid status change', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      // planning → in_progress is not valid (must go through ready first)
+      const result = call('workflow_update_status', {
+        id: created.id,
+        status: 'in_progress',
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('INVALID_TRANSITION');
+      expect(err.recoverable).toBe(false);
+      expect(err.suggestion).toContain('state machine');
+    });
+  });
+
+  // --- workflow_set_parallelism ---
+
+  describe('workflow_set_parallelism', () => {
+    it('updates parallelism settings', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_set_parallelism', {
+        id: created.id,
+        max_parallel_tasks: 4,
+        auto_create_workspaces: true,
+      });
+      expect(result.isError).toBeUndefined();
+      const data = parseContent(result) as { success: boolean };
+      expect(data.success).toBe(true);
+
+      // Verify the change persisted
+      const getResult = call('workflow_get', { id: created.id });
+      const wf = parseContent(getResult) as {
+        max_parallel_tasks: number;
+        auto_create_workspaces: number;
+      };
+      expect(wf.max_parallel_tasks).toBe(4);
+      expect(wf.auto_create_workspaces).toBe(1);
+    });
+
+    it('returns WORKFLOW_NOT_FOUND for missing workflow', () => {
+      const result = call('workflow_set_parallelism', {
+        id: 'wf_nonexistent',
+        max_parallel_tasks: 2,
+      });
+      const err = parseError(result);
+      expect(err.code).toBe('WORKFLOW_NOT_FOUND');
+    });
+  });
+
+  // --- workflow_get_summary ---
+
+  describe('workflow_get_summary', () => {
+    it('returns json summary', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'Summary WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_get_summary', { id: created.id, format: 'json' });
+      expect(result.isError).toBeUndefined();
+      const data = parseContent(result) as { summary: string; token_estimate: number };
+      expect(data.token_estimate).toBeGreaterThan(0);
+
+      const summary = JSON.parse(data.summary);
+      expect(summary.name).toBe('Summary WF');
+      expect(summary.status).toBe('planning');
+    });
+
+    it('returns markdown summary', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'Markdown WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_get_summary', { id: created.id, format: 'markdown' });
+      expect(result.isError).toBeUndefined();
+      const data = parseContent(result) as { summary: string };
+      expect(data.summary).toContain('# Markdown WF');
+      expect(data.summary).toContain('**Status:** planning');
+    });
+
+    it('defaults to json format', () => {
+      const created = parseContent(
+        call('workflow_create', {
+          name: 'Default WF',
+          source_type: 'prompt',
+          source_content: 'x',
+        }),
+      ) as { id: string };
+
+      const result = call('workflow_get_summary', { id: created.id });
+      const data = parseContent(result) as { summary: string };
+      // JSON format produces a parseable JSON string
+      expect(() => JSON.parse(data.summary)).not.toThrow();
+    });
+
+    it('returns WORKFLOW_NOT_FOUND for missing workflow', () => {
+      const result = call('workflow_get_summary', { id: 'wf_nonexistent' });
+      const err = parseError(result);
+      expect(err.code).toBe('WORKFLOW_NOT_FOUND');
+    });
+  });
+
+  // --- structured error format ---
+
+  describe('structured error format', () => {
+    it('includes all required fields in error responses', () => {
+      const result = call('workflow_get', { id: 'wf_missing' });
+      expect(result.isError).toBe(true);
+
+      const err = parseContent(result) as ToolErrorInfo;
+      expect(err).toHaveProperty('code');
+      expect(err).toHaveProperty('message');
+      expect(err).toHaveProperty('recoverable');
+      expect(err).toHaveProperty('suggestion');
+      expect(typeof err.code).toBe('string');
+      expect(typeof err.message).toBe('string');
+      expect(typeof err.recoverable).toBe('boolean');
+      expect(typeof err.suggestion).toBe('string');
+    });
+  });
+});


### PR DESCRIPTION
Closes #17

## Summary
- Add `ToolCallError` class with structured error format (`code`, `message`, `recoverable`, `suggestion`) to `types.ts`
- Update `handleToolCall` to detect `ToolCallError` and return structured JSON error responses while preserving backwards compatibility for plain errors
- Move `workflow_get_summary` tool from `context.ts` to `workflow.ts` to colocate all workflow tools
- Add `toToolCallError` mapper covering 6 error codes: `WORKFLOW_NOT_FOUND`, `INVALID_TRANSITION`, `INVALID_STATE`, `DUPLICATE_TASK_NAME`, `SELF_DEPENDENCY`, `UNKNOWN_DEPENDENCY`
- Add 23 tests in `workflow.test.ts` covering all 7 workflow tools (create, get, list, set_plan, update_status, set_parallelism, get_summary) and structured error format validation

## Testing
- [x] Tests added/updated (23 new tests)
- [x] All tests passing (`bun run test` — 25 mcp-server tests, 0 failures)
- [x] Typecheck passing (`bun run build`)
- [x] Lint passing (`bun run lint`)