### PR TITLE
feat(tui): add workflow detail view

### DIFF
--- a/apps/tui/src/app.tsx
+++ b/apps/tui/src/app.tsx
@@ -2,6 +2,7 @@ import type { DatabaseType } from '@caw/core';
 import { Box, render, Text } from 'ink';
 import type React from 'react';
 import { Dashboard } from './components/Dashboard';
+import { WorkflowDetail } from './components/WorkflowDetail';
 import { DbContext } from './context/db';
 import { useKeyBindings } from './hooks/useKeyBindings';
 import { useAppStore } from './store';
@@ -40,7 +41,7 @@ function HelpView(): React.JSX.Element {
 }
 
 function App(): React.JSX.Element {
-  const { view } = useAppStore();
+  const { view, selectedWorkflowId } = useAppStore();
   useKeyBindings();
 
   return (
@@ -51,7 +52,13 @@ function App(): React.JSX.Element {
         </Text>
         <Text dimColor> — workflow agent</Text>
       </Box>
-      {view === 'help' ? <HelpView /> : <Dashboard />}
+      {view === 'workflow-detail' ? (
+        <WorkflowDetail workflowId={selectedWorkflowId} />
+      ) : view === 'help' ? (
+        <HelpView />
+      ) : (
+        <Dashboard />
+      )}
       <Box paddingX={1}>
         <Text dimColor>q quit | ? help | w/a/t/m panels | r refresh</Text>
       </Box>

--- a/apps/tui/src/components/StatusIndicator.tsx
+++ b/apps/tui/src/components/StatusIndicator.tsx
@@ -1,7 +1,7 @@
 import { Text } from 'ink';
 import type React from 'react';
 
-type StatusKind = 'workflow' | 'agent' | 'task';
+type StatusKind = 'workflow' | 'agent' | 'task' | 'workspace';
 
 interface StatusIndicatorProps {
   kind: StatusKind;
@@ -40,10 +40,17 @@ const taskStyles: Record<string, SymbolStyle> = {
   paused: { symbol: '◐', color: 'yellow' },
 };
 
+const workspaceStyles: Record<string, SymbolStyle> = {
+  active: { symbol: '●', color: 'green' },
+  merged: { symbol: '✓', color: 'blue' },
+  abandoned: { symbol: '○', color: 'gray' },
+};
+
 const styleMap: Record<StatusKind, Record<string, SymbolStyle>> = {
   workflow: workflowStyles,
   agent: agentStyles,
   task: taskStyles,
+  workspace: workspaceStyles,
 };
 
 const fallback: SymbolStyle = { symbol: '?', color: 'gray' };

--- a/apps/tui/src/components/WorkflowDetail.tsx
+++ b/apps/tui/src/components/WorkflowDetail.tsx
@@ -1,0 +1,136 @@
+import { Box, Text, useInput } from 'ink';
+import type React from 'react';
+import { useWorkflowDetail } from '../hooks/useWorkflowDetail';
+import { useAppStore } from '../store';
+import { ProgressBar } from './ProgressBar';
+import { StatusIndicator } from './StatusIndicator';
+import { TaskTree } from './TaskTree';
+
+interface WorkflowDetailProps {
+  workflowId: string | null;
+}
+
+function formatTimestamp(timestamp: number): string {
+  const date = new Date(timestamp);
+  return date.toLocaleString();
+}
+
+export function WorkflowDetail({ workflowId }: WorkflowDetailProps): React.JSX.Element {
+  const { setView } = useAppStore();
+  const { data, error } = useWorkflowDetail(workflowId);
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      setView('dashboard');
+    }
+  });
+
+  if (!workflowId) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text dimColor>No workflow selected</Text>
+      </Box>
+    );
+  }
+
+  if (error) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text color="red">Error: {error.message}</Text>
+      </Box>
+    );
+  }
+
+  if (!data) {
+    return (
+      <Box flexDirection="column" padding={1}>
+        <Text dimColor>Loading...</Text>
+      </Box>
+    );
+  }
+
+  const { workflow, progress, workspaces } = data;
+  const completed = progress?.by_status.completed ?? 0;
+  const total = progress?.total_tasks ?? 0;
+
+  return (
+    <Box flexDirection="column">
+      {/* Header */}
+      <Box flexDirection="column" borderStyle="single" paddingX={1}>
+        <Box gap={1}>
+          <Text bold>Workflow Detail</Text>
+        </Box>
+        <Box gap={1}>
+          <StatusIndicator kind="workflow" status={workflow.status} />
+          <Text bold>{workflow.name}</Text>
+          <Text dimColor>[{workflow.status}]</Text>
+        </Box>
+
+        {/* Source info */}
+        <Box gap={1}>
+          <Text dimColor>Source:</Text>
+          <Text>{workflow.source_type}</Text>
+          {workflow.source_ref && <Text dimColor>(ref: {workflow.source_ref})</Text>}
+        </Box>
+
+        {/* Parallelism config */}
+        <Box gap={1}>
+          <Text dimColor>Parallelism:</Text>
+          <Text>max {workflow.max_parallel_tasks} tasks</Text>
+          {workflow.auto_create_workspaces === 1 && <Text dimColor>(auto worktrees)</Text>}
+        </Box>
+
+        {/* Timestamps */}
+        <Box gap={1}>
+          <Text dimColor>Created:</Text>
+          <Text>{formatTimestamp(workflow.created_at)}</Text>
+        </Box>
+        <Box gap={1}>
+          <Text dimColor>Updated:</Text>
+          <Text>{formatTimestamp(workflow.updated_at)}</Text>
+        </Box>
+
+        {/* Progress section */}
+        {progress && total > 0 && (
+          <Box flexDirection="column" marginTop={1}>
+            <Box gap={1}>
+              <Text dimColor>Progress</Text>
+              <ProgressBar completed={completed} total={total} width={20} />
+            </Box>
+            <Box gap={1}>
+              {Object.entries(progress.by_status).map(([status, count]) => (
+                <Text key={status} dimColor>
+                  {status}: {count}
+                </Text>
+              ))}
+            </Box>
+          </Box>
+        )}
+      </Box>
+
+      {/* Tasks section */}
+      <TaskTree workflowId={workflowId} />
+
+      {/* Workspaces section */}
+      <Box flexDirection="column" borderStyle="single" paddingX={1}>
+        <Text bold>Workspaces ({workspaces.length})</Text>
+        {workspaces.length === 0 ? (
+          <Text dimColor>No workspaces</Text>
+        ) : (
+          workspaces.map((ws) => (
+            <Box key={ws.id} gap={1}>
+              <StatusIndicator kind="workspace" status={ws.status} />
+              <Text>{ws.branch}</Text>
+              <Text dimColor>{ws.path}</Text>
+            </Box>
+          ))
+        )}
+      </Box>
+
+      {/* Footer hint */}
+      <Box paddingX={1}>
+        <Text dimColor>Press Esc to return to dashboard</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/apps/tui/src/components/WorkflowList.tsx
+++ b/apps/tui/src/components/WorkflowList.tsx
@@ -1,4 +1,4 @@
-import { Box, Text } from 'ink';
+import { Box, Text, useInput } from 'ink';
 import type React from 'react';
 import type { WorkflowListItem } from '../hooks/useWorkflows';
 import { useAppStore } from '../store';
@@ -10,8 +10,17 @@ interface WorkflowListProps {
 }
 
 export function WorkflowList({ workflows }: WorkflowListProps): React.JSX.Element {
-  const { activePanel, selectedWorkflowId } = useAppStore();
+  const { activePanel, selectedWorkflowId, setView } = useAppStore();
   const isFocused = activePanel === 'workflows';
+
+  useInput(
+    (_input, key) => {
+      if (key.return && selectedWorkflowId) {
+        setView('workflow-detail');
+      }
+    },
+    { isActive: isFocused },
+  );
 
   return (
     <Box

--- a/apps/tui/src/hooks/useWorkflowDetail.ts
+++ b/apps/tui/src/hooks/useWorkflowDetail.ts
@@ -1,0 +1,38 @@
+import type { ProgressResult, WorkflowWithTasks, Workspace } from '@caw/core';
+import { orchestrationService, workflowService, workspaceService } from '@caw/core';
+import { useDb } from '../context/db';
+import { useAppStore } from '../store';
+import { usePolling } from './usePolling';
+
+export interface WorkflowDetailData {
+  workflow: WorkflowWithTasks;
+  progress: ProgressResult | null;
+  workspaces: Workspace[];
+}
+
+export function useWorkflowDetail(workflowId: string | null) {
+  const db = useDb();
+  const pollInterval = useAppStore((s) => s.pollInterval);
+
+  return usePolling<WorkflowDetailData | null>(() => {
+    if (!workflowId) {
+      return null;
+    }
+
+    const workflow = workflowService.get(db, workflowId, { includeTasks: true });
+    if (!workflow) {
+      return null;
+    }
+
+    let progress: ProgressResult | null = null;
+    try {
+      progress = orchestrationService.getProgress(db, workflowId);
+    } catch {
+      // workflow may not have tasks yet
+    }
+
+    const workspaces = workspaceService.list(db, workflowId);
+
+    return { workflow, progress, workspaces };
+  }, pollInterval);
+}


### PR DESCRIPTION
Closes #38

## Summary
- Add `WorkflowDetail.tsx` component showing comprehensive workflow information
- Add `useWorkflowDetail.ts` hook for data fetching with polling
- Add workspace status styles to `StatusIndicator` component
- Add Enter key navigation from WorkflowList to detail view
- Wire up view routing in `app.tsx`

### Features
- Displays workflow name, status, source info, and parallelism config
- Shows created/updated timestamps
- Includes progress section with progress bar and status breakdown
- Embeds TaskTree component for task visualization
- Lists associated workspaces with status indicators
- Esc key returns to dashboard

## Testing
- [x] Build passes (`bun run --filter @caw/tui build`)
- [x] Lint passes (`bun run --filter @caw/tui lint`)
- [x] Full monorepo build passes (`bun run build`)
- [ ] Manual testing completed