### PR TITLE
feat: command prompt bar with slash commands

### DIFF
--- a/apps/tui/src/app.tsx
+++ b/apps/tui/src/app.tsx
@@ -2,42 +2,60 @@ import type { DatabaseType } from '@caw/core';
 import { Box, render, Text } from 'ink';
 import type React from 'react';
 import { AgentDetail } from './components/AgentDetail';
+import { CommandPrompt } from './components/CommandPrompt';
 import { Dashboard } from './components/Dashboard';
 import { WorkflowDetail } from './components/WorkflowDetail';
 import { DbContext } from './context/db';
 import type { SessionInfo } from './context/session';
 import { SessionContext } from './context/session';
+import { useCommandHandler } from './hooks/useCommandHandler';
 import { useKeyBindings } from './hooks/useKeyBindings';
 import { useAppStore } from './store';
 
 function HelpView(): React.JSX.Element {
   return (
     <Box flexDirection="column" padding={1}>
-      <Text bold>Keybindings</Text>
+      <Text bold>Commands</Text>
       <Text> </Text>
-      <Text>
-        <Text bold>q</Text> Quit
-      </Text>
-      <Text>
-        <Text bold>?</Text> Toggle help
-      </Text>
-      <Text>
-        <Text bold>Esc</Text> Back to dashboard
-      </Text>
-      <Text>
-        <Text bold>w</Text> Focus workflows panel
-      </Text>
-      <Text>
-        <Text bold>a</Text> Focus agents panel
-      </Text>
-      <Text>
-        <Text bold>t</Text> Focus tasks panel
-      </Text>
-      <Text>
-        <Text bold>m</Text> Focus messages panel
-      </Text>
-      <Text>
-        <Text bold>r</Text> Refresh data
+      <Box gap={2}>
+        <Box flexDirection="column">
+          <Text>
+            <Text bold>/workflows</Text> Focus workflows
+          </Text>
+          <Text>
+            <Text bold>/tasks</Text> Focus tasks
+          </Text>
+          <Text>
+            <Text bold>/refresh</Text> Refresh all data
+          </Text>
+          <Text>
+            <Text bold>/lock</Text> Lock workflow
+          </Text>
+          <Text>
+            <Text bold>/help</Text> Show this help
+          </Text>
+        </Box>
+        <Box flexDirection="column">
+          <Text>
+            <Text bold>/agents</Text> Focus agents
+          </Text>
+          <Text>
+            <Text bold>/messages</Text> Focus messages
+          </Text>
+          <Text>
+            <Text bold>/unread</Text> Toggle unread filter
+          </Text>
+          <Text>
+            <Text bold>/unlock</Text> Unlock workflow
+          </Text>
+          <Text>
+            <Text bold>/quit</Text> Exit caw
+          </Text>
+        </Box>
+      </Box>
+      <Text> </Text>
+      <Text dimColor>
+        Keys: Esc clear/back | Arrow keys navigate | Enter select/submit | Tab complete
       </Text>
     </Box>
   );
@@ -46,6 +64,7 @@ function HelpView(): React.JSX.Element {
 function App(): React.JSX.Element {
   const { view, selectedWorkflowId, selectedAgentId } = useAppStore();
   useKeyBindings();
+  const handleSubmit = useCommandHandler();
 
   let content: React.JSX.Element;
   if (view === 'workflow-detail') {
@@ -67,9 +86,7 @@ function App(): React.JSX.Element {
         <Text dimColor> — workflow agent</Text>
       </Box>
       {content}
-      <Box paddingX={1}>
-        <Text dimColor>q quit | ? help | w/a/t/m panels | r refresh</Text>
-      </Box>
+      <CommandPrompt onSubmit={handleSubmit} />
     </Box>
   );
 }

--- a/apps/tui/src/components/AgentList.tsx
+++ b/apps/tui/src/components/AgentList.tsx
@@ -12,6 +12,7 @@ interface AgentListProps {
 
 export function AgentList({ agents, totalUnread }: AgentListProps): React.JSX.Element {
   const { activePanel, selectAgent, setView } = useAppStore();
+  const promptFocused = useAppStore((s) => s.promptFocused);
   const isFocused = activePanel === 'agents';
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -29,7 +30,7 @@ export function AgentList({ agents, totalUnread }: AgentListProps): React.JSX.El
         setSelectedIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
         setSelectedIndex((prev) => Math.min(agents.length - 1, prev + 1));
-      } else if (key.return) {
+      } else if (key.return && !promptFocused) {
         const agent = agents[selectedIndex];
         if (agent) {
           selectAgent(agent.id);

--- a/apps/tui/src/components/CommandPrompt.test.tsx
+++ b/apps/tui/src/components/CommandPrompt.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { render } from 'ink-testing-library';
+import { useAppStore } from '../store';
+import { CommandPrompt } from './CommandPrompt';
+
+describe('CommandPrompt', () => {
+  test('renders default prompt hint', () => {
+    const { lastFrame } = render(<CommandPrompt onSubmit={() => {}} />);
+    expect(lastFrame() ?? '').toContain('Type / for commands');
+  });
+
+  test('renders prompt value when set', () => {
+    useAppStore.setState({ promptValue: '/help' });
+    const { lastFrame } = render(<CommandPrompt onSubmit={() => {}} />);
+    expect(lastFrame() ?? '').toContain('/help');
+    useAppStore.setState({ promptValue: '' });
+  });
+
+  test('renders error feedback', () => {
+    useAppStore.setState({ promptError: 'Unknown command' });
+    const { lastFrame } = render(<CommandPrompt onSubmit={() => {}} />);
+    expect(lastFrame() ?? '').toContain('Unknown command');
+    useAppStore.setState({ promptError: null });
+  });
+
+  test('renders success feedback', () => {
+    useAppStore.setState({ promptSuccess: 'Data refreshed' });
+    const { lastFrame } = render(<CommandPrompt onSubmit={() => {}} />);
+    expect(lastFrame() ?? '').toContain('Data refreshed');
+    useAppStore.setState({ promptSuccess: null });
+  });
+
+  test('renders > prefix', () => {
+    const { lastFrame } = render(<CommandPrompt onSubmit={() => {}} />);
+    expect(lastFrame() ?? '').toContain('>');
+  });
+});

--- a/apps/tui/src/components/CommandPrompt.tsx
+++ b/apps/tui/src/components/CommandPrompt.tsx
@@ -1,0 +1,97 @@
+import { Box, Text, useInput } from 'ink';
+import type React from 'react';
+import { useEffect, useRef } from 'react';
+import { useAppStore } from '../store';
+import { completeCommand } from '../utils/parseCommand';
+
+interface CommandPromptProps {
+  onSubmit: (input: string) => void;
+}
+
+export function CommandPrompt({ onSubmit }: CommandPromptProps): React.JSX.Element {
+  const promptValue = useAppStore((s) => s.promptValue);
+  const promptFocused = useAppStore((s) => s.promptFocused);
+  const promptError = useAppStore((s) => s.promptError);
+  const promptSuccess = useAppStore((s) => s.promptSuccess);
+  const { setPromptValue, setPromptFocused, clearPromptFeedback } = useAppStore();
+
+  // Auto-clear feedback after 5s
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (promptError || promptSuccess) {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        clearPromptFeedback();
+      }, 5000);
+    }
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [promptError, promptSuccess, clearPromptFeedback]);
+
+  useInput((input, key) => {
+    // Ignore ctrl/meta combos — let them pass through
+    if (key.ctrl || key.meta) return;
+
+    // Arrow keys — ignore, let panel handlers deal with them
+    if (key.upArrow || key.downArrow || key.leftArrow || key.rightArrow) return;
+
+    if (key.escape) {
+      setPromptValue('');
+      setPromptFocused(false);
+      clearPromptFeedback();
+      return;
+    }
+
+    if (key.return) {
+      if (promptValue) {
+        onSubmit(promptValue);
+        setPromptValue('');
+        setPromptFocused(false);
+      }
+      return;
+    }
+
+    if (key.backspace || key.delete) {
+      if (promptValue.length > 0) {
+        const newValue = promptValue.slice(0, -1);
+        setPromptValue(newValue);
+        if (newValue.length === 0) {
+          setPromptFocused(false);
+        }
+      }
+      return;
+    }
+
+    if (key.tab) {
+      if (promptValue) {
+        const { completed, candidates } = completeCommand(promptValue);
+        setPromptValue(completed);
+        if (candidates.length > 1) {
+          useAppStore.getState().setPromptSuccess(candidates.map((c) => `/${c}`).join('  '));
+        }
+      }
+      return;
+    }
+
+    // Regular character input
+    if (input && !key.escape && !key.return) {
+      clearPromptFeedback();
+      setPromptValue(promptValue + input);
+      if (!promptFocused) {
+        setPromptFocused(true);
+      }
+    }
+  });
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      {promptError && <Text color="red">{promptError}</Text>}
+      {promptSuccess && !promptError && <Text color="green">{promptSuccess}</Text>}
+      <Box>
+        <Text dimColor={!promptFocused}>{'> '}</Text>
+        {promptValue ? <Text>{promptValue}</Text> : <Text dimColor>Type / for commands</Text>}
+      </Box>
+    </Box>
+  );
+}

--- a/apps/tui/src/components/MessageInbox.tsx
+++ b/apps/tui/src/components/MessageInbox.tsx
@@ -22,7 +22,8 @@ export function MessageInbox({
   isFocused = false,
 }: MessageInboxProps): React.JSX.Element {
   const db = useDb();
-  const { messageStatusFilter, setMessageStatusFilter } = useAppStore();
+  const { messageStatusFilter } = useAppStore();
+  const promptFocused = useAppStore((s) => s.promptFocused);
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [expandedThreadId, setExpandedThreadId] = useState<string | null>(null);
   const [threadMessages, setThreadMessages] = useState<Message[]>([]);
@@ -43,14 +44,14 @@ export function MessageInbox({
   }
 
   useInput(
-    (input, key) => {
+    (_input, key) => {
       if (!filteredMessages || filteredMessages.length === 0) return;
 
       if (key.upArrow) {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
         setSelectedIndex((prev) => Math.min(filteredMessages.length - 1, prev + 1));
-      } else if (key.return) {
+      } else if (key.return && !promptFocused) {
         const msg = filteredMessages[selectedIndex];
         if (msg?.thread_id) {
           if (expandedThreadId === msg.thread_id) {
@@ -61,8 +62,6 @@ export function MessageInbox({
             setThreadMessages(messageService.getThread(db, msg.thread_id));
           }
         }
-      } else if (input === 'u') {
-        setMessageStatusFilter(messageStatusFilter === 'unread' ? 'all' : 'unread');
       }
     },
     { isActive: isFocused },
@@ -109,7 +108,7 @@ export function MessageInbox({
           );
         })
       )}
-      {isFocused && <Text dimColor>↑↓ navigate | Enter expand thread | u toggle unread</Text>}
+      {isFocused && <Text dimColor>↑↓ navigate | Enter expand thread | /unread toggle filter</Text>}
     </Box>
   );
 }

--- a/apps/tui/src/components/MessagePanel.tsx
+++ b/apps/tui/src/components/MessagePanel.tsx
@@ -8,6 +8,7 @@ import { TypeBadge } from './TypeBadge';
 
 export function MessagePanel(): React.JSX.Element {
   const { activePanel, selectAgent, setView } = useAppStore();
+  const promptFocused = useAppStore((s) => s.promptFocused);
   const isFocused = activePanel === 'messages';
   const { data, error } = useAllMessages();
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -29,7 +30,7 @@ export function MessagePanel(): React.JSX.Element {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
         setSelectedIndex((prev) => Math.min(messages.length - 1, prev + 1));
-      } else if (key.return) {
+      } else if (key.return && !promptFocused) {
         const msg = messages[selectedIndex];
         if (msg) {
           selectAgent(msg.recipient_id);

--- a/apps/tui/src/components/TaskTree.tsx
+++ b/apps/tui/src/components/TaskTree.tsx
@@ -50,6 +50,7 @@ interface TaskTreeProps {
 
 export function TaskTree({ workflowId }: TaskTreeProps): React.JSX.Element {
   const { activePanel, selectTask } = useAppStore();
+  const promptFocused = useAppStore((s) => s.promptFocused);
   const isFocused = activePanel === 'tasks';
   const { data: tasks, error } = useTasks(workflowId);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -68,7 +69,7 @@ export function TaskTree({ workflowId }: TaskTreeProps): React.JSX.Element {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
       } else if (key.downArrow) {
         setSelectedIndex((prev) => Math.min(tasks.length - 1, prev + 1));
-      } else if (key.return) {
+      } else if (key.return && !promptFocused) {
         const selectedTask = tasks[selectedIndex];
         if (selectedTask) {
           selectTask(selectedTask.id);

--- a/apps/tui/src/components/WorkflowList.tsx
+++ b/apps/tui/src/components/WorkflowList.tsx
@@ -11,11 +11,12 @@ interface WorkflowListProps {
 
 export function WorkflowList({ workflows }: WorkflowListProps): React.JSX.Element {
   const { activePanel, selectedWorkflowId, setView } = useAppStore();
+  const promptFocused = useAppStore((s) => s.promptFocused);
   const isFocused = activePanel === 'workflows';
 
   useInput(
     (_input, key) => {
-      if (key.return && selectedWorkflowId) {
+      if (key.return && !promptFocused && selectedWorkflowId) {
         setView('workflow-detail');
       }
     },

--- a/apps/tui/src/hooks/useAgentDetail.ts
+++ b/apps/tui/src/hooks/useAgentDetail.ts
@@ -14,29 +14,34 @@ export interface AgentDetailData {
 export function useAgentDetail(agentId: string | null) {
   const db = useDb();
   const pollInterval = useAppStore((s) => s.pollInterval);
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  return usePolling<AgentDetailData | null>(() => {
-    if (!agentId) {
-      return null;
-    }
-
-    const agent = agentService.get(db, agentId);
-    if (!agent) {
-      return null;
-    }
-
-    const messages = messageService.list(db, agentId, { limit: 50 });
-    const unreadCount = messageService.countUnread(db, agentId);
-
-    let capabilities: string[] = [];
-    if (agent.capabilities) {
-      try {
-        capabilities = JSON.parse(agent.capabilities);
-      } catch {
-        // ignore malformed JSON
+  return usePolling<AgentDetailData | null>(
+    () => {
+      if (!agentId) {
+        return null;
       }
-    }
 
-    return { agent, messages, unreadCount, capabilities };
-  }, pollInterval);
+      const agent = agentService.get(db, agentId);
+      if (!agent) {
+        return null;
+      }
+
+      const messages = messageService.list(db, agentId, { limit: 50 });
+      const unreadCount = messageService.countUnread(db, agentId);
+
+      let capabilities: string[] = [];
+      if (agent.capabilities) {
+        try {
+          capabilities = JSON.parse(agent.capabilities);
+        } catch {
+          // ignore malformed JSON
+        }
+      }
+
+      return { agent, messages, unreadCount, capabilities };
+    },
+    pollInterval,
+    lastRefreshAt,
+  );
 }

--- a/apps/tui/src/hooks/useAgents.ts
+++ b/apps/tui/src/hooks/useAgents.ts
@@ -7,8 +7,13 @@ import { usePolling } from './usePolling';
 export function useAgents() {
   const db = useDb();
   const pollInterval = useAppStore((s) => s.pollInterval);
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  return usePolling<Agent[]>(() => {
-    return agentService.list(db);
-  }, pollInterval);
+  return usePolling<Agent[]>(
+    () => {
+      return agentService.list(db);
+    },
+    pollInterval,
+    lastRefreshAt,
+  );
 }

--- a/apps/tui/src/hooks/useCommandHandler.test.ts
+++ b/apps/tui/src/hooks/useCommandHandler.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from 'bun:test';
+import { useCommandHandler } from './useCommandHandler';
+
+describe('useCommandHandler', () => {
+  test('exports useCommandHandler as a function', () => {
+    expect(typeof useCommandHandler).toBe('function');
+  });
+});

--- a/apps/tui/src/hooks/useCommandHandler.ts
+++ b/apps/tui/src/hooks/useCommandHandler.ts
@@ -1,0 +1,128 @@
+import { lockService } from '@caw/core';
+import { useApp } from 'ink';
+import { useCallback } from 'react';
+import { useDb } from '../context/db';
+import { useSessionInfo } from '../context/session';
+import type { Panel } from '../store';
+import { useAppStore } from '../store';
+import { isValidSlashCommand, parseCommand } from '../utils/parseCommand';
+
+const panelCommands: Record<string, Panel> = {
+  workflows: 'workflows',
+  tasks: 'tasks',
+  agents: 'agents',
+  messages: 'messages',
+};
+
+export function useCommandHandler(): (input: string) => void {
+  const { exit } = useApp();
+  const db = useDb();
+  const sessionInfo = useSessionInfo();
+
+  return useCallback(
+    (input: string) => {
+      const parsed = parseCommand(input);
+      const store = useAppStore.getState();
+
+      if (parsed.type === 'text') {
+        store.setPromptError('Workflow creation from prompt is not yet available');
+        return;
+      }
+
+      const { command } = parsed;
+
+      if (!command || !isValidSlashCommand(command)) {
+        store.setPromptError(`Unknown command: /${command ?? ''}`);
+        return;
+      }
+
+      if (command === 'quit') {
+        exit();
+        return;
+      }
+
+      if (command === 'help') {
+        store.setView('help');
+        return;
+      }
+
+      if (panelCommands[command]) {
+        store.setView('dashboard');
+        store.setActivePanel(panelCommands[command]);
+        return;
+      }
+
+      if (command === 'refresh') {
+        store.triggerRefresh();
+        store.setPromptSuccess('Data refreshed');
+        return;
+      }
+
+      if (command === 'unread') {
+        const current = store.messageStatusFilter;
+        const next = current === 'unread' ? 'all' : 'unread';
+        store.setMessageStatusFilter(next);
+        store.setPromptSuccess(`Message filter: ${next}`);
+        return;
+      }
+
+      if (command === 'lock') {
+        if (!sessionInfo) {
+          store.setPromptError('No active session — cannot lock');
+          return;
+        }
+        const wfId = parsed.args ?? store.selectedWorkflowId;
+        if (!wfId) {
+          store.setPromptError('No workflow selected. Usage: /lock <workflow_id>');
+          return;
+        }
+        try {
+          const result = lockService.lock(db, wfId, sessionInfo.sessionId);
+          if (result.success) {
+            store.setPromptSuccess(`Locked workflow ${wfId}`);
+            store.triggerRefresh();
+          } else {
+            store.setPromptError(
+              `Workflow already locked by session ${result.locked_by ?? 'unknown'}`,
+            );
+          }
+        } catch (err) {
+          store.setPromptError(`Lock failed: ${err instanceof Error ? err.message : String(err)}`);
+        }
+        return;
+      }
+
+      if (command === 'unlock') {
+        if (!sessionInfo) {
+          store.setPromptError('No active session — cannot unlock');
+          return;
+        }
+        const wfId = parsed.args ?? store.selectedWorkflowId;
+        if (!wfId) {
+          store.setPromptError('No workflow selected. Usage: /unlock <workflow_id>');
+          return;
+        }
+        try {
+          const unlocked = lockService.unlock(db, wfId, sessionInfo.sessionId);
+          if (unlocked) {
+            store.setPromptSuccess(`Unlocked workflow ${wfId}`);
+            store.triggerRefresh();
+          } else {
+            store.setPromptError('Unlock failed — you may not hold the lock');
+          }
+        } catch (err) {
+          store.setPromptError(
+            `Unlock failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        return;
+      }
+
+      if (command === 'dag' || command === 'tree') {
+        store.setPromptError(`/${command} is not yet implemented`);
+        return;
+      }
+    },
+    [exit, db, sessionInfo],
+  );
+}

--- a/apps/tui/src/hooks/useKeyBindings.ts
+++ b/apps/tui/src/hooks/useKeyBindings.ts
@@ -1,41 +1,13 @@
-import { useApp, useInput } from 'ink';
-import type { Panel } from '../store';
+import { useInput } from 'ink';
 import { useAppStore } from '../store';
 
-const panelKeys: Record<string, Panel> = {
-  w: 'workflows',
-  a: 'agents',
-  t: 'tasks',
-  m: 'messages',
-};
-
-export function useKeyBindings(onRefresh?: () => void): void {
-  const { exit } = useApp();
-  const { view, setView, setActivePanel } = useAppStore();
-
-  useInput((input, key) => {
-    if (input === 'q') {
-      exit();
-      return;
-    }
-
-    if (input === '?') {
-      setView(view === 'help' ? 'dashboard' : 'help');
-      return;
-    }
-
+export function useKeyBindings(): void {
+  useInput((_input, key) => {
     if (key.escape) {
-      setView('dashboard');
-      return;
-    }
-
-    if (view === 'dashboard' && panelKeys[input]) {
-      setActivePanel(panelKeys[input]);
-      return;
-    }
-
-    if (input === 'r' && onRefresh) {
-      onRefresh();
+      const { promptFocused, promptValue } = useAppStore.getState();
+      if (!promptFocused && !promptValue) {
+        useAppStore.getState().setView('dashboard');
+      }
     }
   });
 }

--- a/apps/tui/src/hooks/useMessages.ts
+++ b/apps/tui/src/hooks/useMessages.ts
@@ -17,27 +17,37 @@ export interface AllMessagesData {
 export function useMessages(agentId: string | null, filters?: MessageListFilters) {
   const db = useDb();
   const pollInterval = useAppStore((s) => s.pollInterval);
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  return usePolling<MessagesData | null>(() => {
-    if (!agentId) {
-      return null;
-    }
+  return usePolling<MessagesData | null>(
+    () => {
+      if (!agentId) {
+        return null;
+      }
 
-    const messages = messageService.list(db, agentId, filters);
-    const unreadCount = messageService.countUnread(db, agentId);
+      const messages = messageService.list(db, agentId, filters);
+      const unreadCount = messageService.countUnread(db, agentId);
 
-    return { messages, unreadCount };
-  }, pollInterval);
+      return { messages, unreadCount };
+    },
+    pollInterval,
+    lastRefreshAt,
+  );
 }
 
 export function useAllMessages() {
   const db = useDb();
   const pollInterval = useAppStore((s) => s.pollInterval);
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  return usePolling<AllMessagesData>(() => {
-    const messages = messageService.listAll(db, { limit: 50 });
-    const totalUnread = messageService.countAllUnread(db);
+  return usePolling<AllMessagesData>(
+    () => {
+      const messages = messageService.listAll(db, { limit: 50 });
+      const totalUnread = messageService.countAllUnread(db);
 
-    return { messages, totalUnread };
-  }, pollInterval);
+      return { messages, totalUnread };
+    },
+    pollInterval,
+    lastRefreshAt,
+  );
 }

--- a/apps/tui/src/hooks/usePolling.ts
+++ b/apps/tui/src/hooks/usePolling.ts
@@ -7,7 +7,11 @@ export interface UsePollingResult<T> {
   refresh: () => void;
 }
 
-export function usePolling<T>(fetcher: () => T, interval = 2000): UsePollingResult<T> {
+export function usePolling<T>(
+  fetcher: () => T,
+  interval = 2000,
+  refreshTrigger = 0,
+): UsePollingResult<T> {
   const [data, setData] = useState<T | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
@@ -29,11 +33,12 @@ export function usePolling<T>(fetcher: () => T, interval = 2000): UsePollingResu
     }
   }, []);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshTrigger intentionally resets the polling interval
   useEffect(() => {
     run();
     const id = setInterval(run, interval);
     return () => clearInterval(id);
-  }, [run, interval]);
+  }, [run, interval, refreshTrigger]);
 
   return { data, loading, error, refresh: run };
 }

--- a/apps/tui/src/hooks/useSession.ts
+++ b/apps/tui/src/hooks/useSession.ts
@@ -2,22 +2,33 @@ import type { Session } from '@caw/core';
 import { sessionService } from '@caw/core';
 import { useDb } from '../context/db';
 import { useSessionInfo } from '../context/session';
+import { useAppStore } from '../store';
 import { usePolling } from './usePolling';
 
 export function useSessionList() {
   const db = useDb();
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  return usePolling<Session[]>(() => {
-    return sessionService.list(db);
-  }, 5000);
+  return usePolling<Session[]>(
+    () => {
+      return sessionService.list(db);
+    },
+    5000,
+    lastRefreshAt,
+  );
 }
 
 export function useCurrentSession() {
   const db = useDb();
   const info = useSessionInfo();
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  return usePolling<Session | null>(() => {
-    if (!info) return null;
-    return sessionService.get(db, info.sessionId);
-  }, 5000);
+  return usePolling<Session | null>(
+    () => {
+      if (!info) return null;
+      return sessionService.get(db, info.sessionId);
+    },
+    5000,
+    lastRefreshAt,
+  );
 }

--- a/apps/tui/src/hooks/useTasks.ts
+++ b/apps/tui/src/hooks/useTasks.ts
@@ -147,65 +147,70 @@ export function buildTaskTree(
 export function useTasks(workflowId: string | null) {
   const db = useDb();
   const pollInterval = useAppStore((s) => s.pollInterval);
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  const rawData = usePolling(() => {
-    if (!workflowId) return null;
+  const rawData = usePolling(
+    () => {
+      if (!workflowId) return null;
 
-    const workflow = workflowService.get(db, workflowId, { includeTasks: true });
-    if (!workflow) return null;
+      const workflow = workflowService.get(db, workflowId, { includeTasks: true });
+      if (!workflow) return null;
 
-    const tasks = workflow.tasks as RawTaskData[];
-    if (tasks.length === 0) {
-      return { tasks: [], dependencies: [], agentNames: new Map(), checkpointCounts: new Map() };
-    }
-
-    // Get all task IDs
-    const taskIds = tasks.map((t) => t.id);
-
-    // Query dependencies for all tasks (batched)
-    let allDependencies: TaskDependency[] = [];
-    if (taskIds.length > 0) {
-      const placeholders = taskIds.map(() => '?').join(',');
-      allDependencies = db
-        .prepare(`SELECT * FROM task_dependencies WHERE task_id IN (${placeholders})`)
-        .all(...taskIds) as TaskDependency[];
-    }
-
-    // Get agent names for assigned tasks
-    const agentNames = new Map<string, string>();
-    const agentIds = new Set<string>();
-    for (const t of tasks) {
-      if (t.assigned_agent_id) {
-        agentIds.add(t.assigned_agent_id);
+      const tasks = workflow.tasks as RawTaskData[];
+      if (tasks.length === 0) {
+        return { tasks: [], dependencies: [], agentNames: new Map(), checkpointCounts: new Map() };
       }
-    }
-    const agentIdArray = Array.from(agentIds);
-    if (agentIdArray.length > 0) {
-      const placeholders = agentIdArray.map(() => '?').join(',');
-      const rows = db
-        .prepare(`SELECT id, name FROM agents WHERE id IN (${placeholders})`)
-        .all(...agentIdArray) as { id: string; name: string }[];
-      for (const row of rows) {
-        agentNames.set(row.id, row.name);
-      }
-    }
 
-    // Get checkpoint counts per task (batched with GROUP BY)
-    const checkpointCounts = new Map<string, number>();
-    if (taskIds.length > 0) {
-      const placeholders = taskIds.map(() => '?').join(',');
-      const rows = db
-        .prepare(
-          `SELECT task_id, COUNT(*) as count FROM checkpoints WHERE task_id IN (${placeholders}) GROUP BY task_id`,
-        )
-        .all(...taskIds) as { task_id: string; count: number }[];
-      for (const row of rows) {
-        checkpointCounts.set(row.task_id, row.count);
-      }
-    }
+      // Get all task IDs
+      const taskIds = tasks.map((t) => t.id);
 
-    return { tasks, dependencies: allDependencies, agentNames, checkpointCounts };
-  }, pollInterval);
+      // Query dependencies for all tasks (batched)
+      let allDependencies: TaskDependency[] = [];
+      if (taskIds.length > 0) {
+        const placeholders = taskIds.map(() => '?').join(',');
+        allDependencies = db
+          .prepare(`SELECT * FROM task_dependencies WHERE task_id IN (${placeholders})`)
+          .all(...taskIds) as TaskDependency[];
+      }
+
+      // Get agent names for assigned tasks
+      const agentNames = new Map<string, string>();
+      const agentIds = new Set<string>();
+      for (const t of tasks) {
+        if (t.assigned_agent_id) {
+          agentIds.add(t.assigned_agent_id);
+        }
+      }
+      const agentIdArray = Array.from(agentIds);
+      if (agentIdArray.length > 0) {
+        const placeholders = agentIdArray.map(() => '?').join(',');
+        const rows = db
+          .prepare(`SELECT id, name FROM agents WHERE id IN (${placeholders})`)
+          .all(...agentIdArray) as { id: string; name: string }[];
+        for (const row of rows) {
+          agentNames.set(row.id, row.name);
+        }
+      }
+
+      // Get checkpoint counts per task (batched with GROUP BY)
+      const checkpointCounts = new Map<string, number>();
+      if (taskIds.length > 0) {
+        const placeholders = taskIds.map(() => '?').join(',');
+        const rows = db
+          .prepare(
+            `SELECT task_id, COUNT(*) as count FROM checkpoints WHERE task_id IN (${placeholders}) GROUP BY task_id`,
+          )
+          .all(...taskIds) as { task_id: string; count: number }[];
+        for (const row of rows) {
+          checkpointCounts.set(row.task_id, row.count);
+        }
+      }
+
+      return { tasks, dependencies: allDependencies, agentNames, checkpointCounts };
+    },
+    pollInterval,
+    lastRefreshAt,
+  );
 
   const treeData = useMemo(() => {
     if (!rawData.data) return null;

--- a/apps/tui/src/hooks/useWorkflowDetail.ts
+++ b/apps/tui/src/hooks/useWorkflowDetail.ts
@@ -13,26 +13,31 @@ export interface WorkflowDetailData {
 export function useWorkflowDetail(workflowId: string | null) {
   const db = useDb();
   const pollInterval = useAppStore((s) => s.pollInterval);
+  const lastRefreshAt = useAppStore((s) => s.lastRefreshAt);
 
-  return usePolling<WorkflowDetailData | null>(() => {
-    if (!workflowId) {
-      return null;
-    }
+  return usePolling<WorkflowDetailData | null>(
+    () => {
+      if (!workflowId) {
+        return null;
+      }
 
-    const workflow = workflowService.get(db, workflowId, { includeTasks: true });
-    if (!workflow) {
-      return null;
-    }
+      const workflow = workflowService.get(db, workflowId, { includeTasks: true });
+      if (!workflow) {
+        return null;
+      }
 
-    let progress: ProgressResult | null = null;
-    try {
-      progress = orchestrationService.getProgress(db, workflowId);
-    } catch {
-      // workflow may not have tasks yet
-    }
+      let progress: ProgressResult | null = null;
+      try {
+        progress = orchestrationService.getProgress(db, workflowId);
+      } catch {
+        // workflow may not have tasks yet
+      }
 
-    const workspaces = workspaceService.list(db, workflowId);
+      const workspaces = workspaceService.list(db, workflowId);
 
-    return { workflow, progress, workspaces };
-  }, pollInterval);
+      return { workflow, progress, workspaces };
+    },
+    pollInterval,
+    lastRefreshAt,
+  );
 }

--- a/apps/tui/src/store/index.test.ts
+++ b/apps/tui/src/store/index.test.ts
@@ -14,6 +14,11 @@ describe('useAppStore', () => {
       selectedThreadId: null,
       messageStatusFilter: 'all',
       pollInterval: 2000,
+      promptValue: '',
+      promptFocused: false,
+      promptError: null,
+      promptSuccess: null,
+      lastRefreshAt: 0,
     });
   });
 
@@ -28,6 +33,11 @@ describe('useAppStore', () => {
     expect(state.selectedThreadId).toBeNull();
     expect(state.messageStatusFilter).toBe('all');
     expect(state.pollInterval).toBe(2000);
+    expect(state.promptValue).toBe('');
+    expect(state.promptFocused).toBe(false);
+    expect(state.promptError).toBeNull();
+    expect(state.promptSuccess).toBeNull();
+    expect(state.lastRefreshAt).toBe(0);
   });
 
   test('setView updates view', () => {
@@ -135,6 +145,58 @@ describe('useAppStore', () => {
     expect(state.view).toBe('dashboard');
     expect(state.selectedWorkflowId).toBeNull();
     expect(state.selectedTaskId).toBeNull();
+  });
+
+  test('setPromptValue updates promptValue', () => {
+    useAppStore.getState().setPromptValue('/help');
+    expect(useAppStore.getState().promptValue).toBe('/help');
+
+    useAppStore.getState().setPromptValue('');
+    expect(useAppStore.getState().promptValue).toBe('');
+  });
+
+  test('setPromptFocused updates promptFocused', () => {
+    useAppStore.getState().setPromptFocused(true);
+    expect(useAppStore.getState().promptFocused).toBe(true);
+
+    useAppStore.getState().setPromptFocused(false);
+    expect(useAppStore.getState().promptFocused).toBe(false);
+  });
+
+  test('setPromptError updates promptError', () => {
+    useAppStore.getState().setPromptError('Something went wrong');
+    expect(useAppStore.getState().promptError).toBe('Something went wrong');
+
+    useAppStore.getState().setPromptError(null);
+    expect(useAppStore.getState().promptError).toBeNull();
+  });
+
+  test('setPromptSuccess updates promptSuccess', () => {
+    useAppStore.getState().setPromptSuccess('Data refreshed');
+    expect(useAppStore.getState().promptSuccess).toBe('Data refreshed');
+
+    useAppStore.getState().setPromptSuccess(null);
+    expect(useAppStore.getState().promptSuccess).toBeNull();
+  });
+
+  test('triggerRefresh updates lastRefreshAt', () => {
+    const before = Date.now();
+    useAppStore.getState().triggerRefresh();
+    const after = Date.now();
+
+    const value = useAppStore.getState().lastRefreshAt;
+    expect(value).toBeGreaterThanOrEqual(before);
+    expect(value).toBeLessThanOrEqual(after);
+  });
+
+  test('clearPromptFeedback clears both error and success', () => {
+    useAppStore.getState().setPromptError('error');
+    useAppStore.getState().setPromptSuccess('success');
+    useAppStore.getState().clearPromptFeedback();
+
+    const state = useAppStore.getState();
+    expect(state.promptError).toBeNull();
+    expect(state.promptSuccess).toBeNull();
   });
 
   test('agent detail with message filter flow', () => {

--- a/apps/tui/src/store/index.ts
+++ b/apps/tui/src/store/index.ts
@@ -15,6 +15,11 @@ interface AppState {
   selectedThreadId: string | null;
   messageStatusFilter: MessageStatusFilter;
   pollInterval: number;
+  promptValue: string;
+  promptFocused: boolean;
+  promptError: string | null;
+  promptSuccess: string | null;
+  lastRefreshAt: number;
 
   setView: (view: View) => void;
   setActivePanel: (panel: Panel) => void;
@@ -25,6 +30,12 @@ interface AppState {
   selectThread: (id: string | null) => void;
   setMessageStatusFilter: (filter: MessageStatusFilter) => void;
   setPollInterval: (interval: number) => void;
+  setPromptValue: (value: string) => void;
+  setPromptFocused: (focused: boolean) => void;
+  setPromptError: (error: string | null) => void;
+  setPromptSuccess: (success: string | null) => void;
+  triggerRefresh: () => void;
+  clearPromptFeedback: () => void;
 }
 
 export const useAppStore = create<AppState>((set) => ({
@@ -37,6 +48,11 @@ export const useAppStore = create<AppState>((set) => ({
   selectedThreadId: null,
   messageStatusFilter: 'all',
   pollInterval: 2000,
+  promptValue: '',
+  promptFocused: false,
+  promptError: null,
+  promptSuccess: null,
+  lastRefreshAt: 0,
 
   setView: (view) => set({ view }),
   setActivePanel: (panel) => set({ activePanel: panel }),
@@ -47,4 +63,10 @@ export const useAppStore = create<AppState>((set) => ({
   selectThread: (id) => set({ selectedThreadId: id }),
   setMessageStatusFilter: (filter) => set({ messageStatusFilter: filter }),
   setPollInterval: (interval) => set({ pollInterval: interval }),
+  setPromptValue: (value) => set({ promptValue: value }),
+  setPromptFocused: (focused) => set({ promptFocused: focused }),
+  setPromptError: (error) => set({ promptError: error }),
+  setPromptSuccess: (success) => set({ promptSuccess: success }),
+  triggerRefresh: () => set({ lastRefreshAt: Date.now() }),
+  clearPromptFeedback: () => set({ promptError: null, promptSuccess: null }),
 }));

--- a/apps/tui/src/utils/parseCommand.test.ts
+++ b/apps/tui/src/utils/parseCommand.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from 'bun:test';
+import { completeCommand, isValidSlashCommand, parseCommand, SLASH_COMMANDS } from './parseCommand';
+
+describe('parseCommand', () => {
+  test('parses simple slash command', () => {
+    expect(parseCommand('/help')).toEqual({ type: 'slash', command: 'help' });
+  });
+
+  test('parses slash command with args', () => {
+    expect(parseCommand('/lock wf_abc123')).toEqual({
+      type: 'slash',
+      command: 'lock',
+      args: 'wf_abc123',
+    });
+  });
+
+  test('normalizes command to lowercase', () => {
+    expect(parseCommand('/HELP')).toEqual({ type: 'slash', command: 'help' });
+    expect(parseCommand('/Lock WF_ID')).toEqual({
+      type: 'slash',
+      command: 'lock',
+      args: 'WF_ID',
+    });
+  });
+
+  test('parses plain text as text type', () => {
+    expect(parseCommand('hello world')).toEqual({ type: 'text', text: 'hello world' });
+  });
+
+  test('handles empty string', () => {
+    expect(parseCommand('')).toEqual({ type: 'text', text: '' });
+  });
+
+  test('handles slash alone', () => {
+    expect(parseCommand('/')).toEqual({ type: 'slash', command: '' });
+  });
+
+  test('trims whitespace', () => {
+    expect(parseCommand('  /help  ')).toEqual({ type: 'slash', command: 'help' });
+    expect(parseCommand('  hello  ')).toEqual({ type: 'text', text: 'hello' });
+  });
+
+  test('handles args with extra whitespace', () => {
+    expect(parseCommand('/lock   wf_abc  ')).toEqual({
+      type: 'slash',
+      command: 'lock',
+      args: 'wf_abc',
+    });
+  });
+
+  test('handles command with empty args', () => {
+    expect(parseCommand('/help ')).toEqual({ type: 'slash', command: 'help' });
+  });
+
+  test('all defined slash commands parse correctly', () => {
+    for (const cmd of SLASH_COMMANDS) {
+      const result = parseCommand(`/${cmd}`);
+      expect(result.type).toBe('slash');
+      expect(result.command).toBe(cmd);
+    }
+  });
+});
+
+describe('isValidSlashCommand', () => {
+  test('returns true for valid commands', () => {
+    expect(isValidSlashCommand('help')).toBe(true);
+    expect(isValidSlashCommand('quit')).toBe(true);
+    expect(isValidSlashCommand('workflows')).toBe(true);
+    expect(isValidSlashCommand('lock')).toBe(true);
+  });
+
+  test('returns false for invalid commands', () => {
+    expect(isValidSlashCommand('foo')).toBe(false);
+    expect(isValidSlashCommand('')).toBe(false);
+    expect(isValidSlashCommand('HELP')).toBe(false);
+  });
+});
+
+describe('completeCommand', () => {
+  test('completes single match', () => {
+    expect(completeCommand('/he')).toEqual({
+      completed: '/help',
+      candidates: ['help'],
+    });
+  });
+
+  test('completes exact match', () => {
+    expect(completeCommand('/workflows')).toEqual({
+      completed: '/workflows',
+      candidates: ['workflows'],
+    });
+  });
+
+  test('returns common prefix for ambiguous input', () => {
+    const result = completeCommand('/un');
+    expect(result.completed).toBe('/un');
+    expect(result.candidates).toContain('unread');
+    expect(result.candidates).toContain('unlock');
+    expect(result.candidates.length).toBe(2);
+  });
+
+  test('no-op for non-slash input', () => {
+    expect(completeCommand('hello')).toEqual({
+      completed: 'hello',
+      candidates: [],
+    });
+  });
+
+  test('no matches for unknown prefix', () => {
+    expect(completeCommand('/xyz')).toEqual({
+      completed: '/xyz',
+      candidates: [],
+    });
+  });
+
+  test('slash alone returns all commands', () => {
+    const result = completeCommand('/');
+    expect(result.completed).toBe('/');
+    expect(result.candidates.length).toBe(SLASH_COMMANDS.length);
+  });
+
+  test('completes single-char prefix', () => {
+    const result = completeCommand('/q');
+    expect(result.completed).toBe('/quit');
+    expect(result.candidates).toEqual(['quit']);
+  });
+
+  test('handles lock/unlock ambiguity with /l prefix', () => {
+    const result = completeCommand('/l');
+    expect(result.completed).toBe('/lock');
+    expect(result.candidates).toEqual(['lock']);
+  });
+});

--- a/apps/tui/src/utils/parseCommand.ts
+++ b/apps/tui/src/utils/parseCommand.ts
@@ -1,0 +1,86 @@
+export type CommandType = 'slash' | 'text';
+
+export interface ParsedCommand {
+  type: CommandType;
+  command?: string;
+  args?: string;
+  text?: string;
+}
+
+export const SLASH_COMMANDS = [
+  'quit',
+  'help',
+  'workflows',
+  'tasks',
+  'agents',
+  'messages',
+  'refresh',
+  'unread',
+  'lock',
+  'unlock',
+  'dag',
+  'tree',
+] as const;
+
+export type SlashCommand = (typeof SLASH_COMMANDS)[number];
+
+export function isValidSlashCommand(command: string): command is SlashCommand {
+  return SLASH_COMMANDS.includes(command as SlashCommand);
+}
+
+export function parseCommand(input: string): ParsedCommand {
+  const trimmed = input.trim();
+
+  if (!trimmed.startsWith('/')) {
+    return { type: 'text', text: trimmed };
+  }
+
+  const withoutSlash = trimmed.slice(1);
+  const spaceIndex = withoutSlash.indexOf(' ');
+
+  if (spaceIndex === -1) {
+    return { type: 'slash', command: withoutSlash.toLowerCase() };
+  }
+
+  const command = withoutSlash.slice(0, spaceIndex).toLowerCase();
+  const args = withoutSlash.slice(spaceIndex + 1).trim();
+
+  return { type: 'slash', command, args: args || undefined };
+}
+
+export function completeCommand(partial: string): {
+  completed: string;
+  candidates: string[];
+} {
+  if (!partial.startsWith('/')) {
+    return { completed: partial, candidates: [] };
+  }
+
+  const withoutSlash = partial.slice(1).toLowerCase();
+
+  if (!withoutSlash) {
+    return { completed: partial, candidates: [...SLASH_COMMANDS] };
+  }
+
+  const matches = SLASH_COMMANDS.filter((cmd) => cmd.startsWith(withoutSlash));
+
+  if (matches.length === 0) {
+    return { completed: partial, candidates: [] };
+  }
+
+  if (matches.length === 1) {
+    return { completed: `/${matches[0]}`, candidates: [...matches] };
+  }
+
+  // Find longest common prefix among matches
+  let prefix: string = matches[0];
+  for (let i = 1; i < matches.length; i++) {
+    let j = 0;
+    while (j < prefix.length && j < matches[i].length && prefix[j] === matches[i][j]) {
+      j++;
+    }
+    prefix = prefix.slice(0, j);
+  }
+
+  return { completed: `/${prefix}`, candidates: [...matches] };
+}


### PR DESCRIPTION
Closes #70

## Summary
- Added persistent command prompt bar at the bottom of the TUI, replacing single-key bindings (q, ?, w, a, t, m, r) with `/slash-commands`
- Implemented `parseCommand` utility with slash command parsing, validation, and tab-completion
- Created `CommandPrompt` component with character input, Enter submit, Escape clear, Backspace delete, Tab completion, and auto-clearing feedback messages
- Built `useCommandHandler` hook dispatching 12 commands: `/quit`, `/help`, `/workflows`, `/tasks`, `/agents`, `/messages`, `/refresh`, `/unread`, `/lock`, `/unlock`, `/dag`, `/tree`
- Added `refreshTrigger` parameter to `usePolling` and wired `lastRefreshAt` store field into all 8 data hooks for `/refresh` support
- Stripped `useKeyBindings` to Escape-only with prompt-aware logic (first Escape clears prompt, second returns to dashboard)
- Added `promptFocused` guard on Enter key in 5 panel components to prevent conflicts with prompt submission
- Updated `HelpView` to display slash commands instead of old keybindings
- Removed `'u'` single-key binding from `MessageInbox` (replaced by `/unread` command)

## Testing
- [x] Tests added/updated (148 TUI tests, up from 115 — 33 new tests across 3 new test files + expanded store tests)
- [x] All tests passing (`bun run test` — 0 failures)
- [x] Manual testing completed
- [x] TypeScript typecheck clean (`bun run build`)
- [x] Lint clean (`bun run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)