### PR TITLE
feat: set process.title to 'caw' for process identification (#88)

### DIFF
--- a/apps/tui/src/bin/cli.ts
+++ b/apps/tui/src/bin/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env bun
+process.title = 'caw';
+
 import { parseArgs } from 'node:util';
 import { createConnection, getDbPath, runMigrations, templateService } from '@caw/core';
 


### PR DESCRIPTION
## Summary
- Sets `process.title = 'caw'` at the top of the CLI entrypoint (`apps/tui/src/bin/cli.ts`) so the process appears as `caw` instead of `bun` in system monitors (`ps`, `top`, Activity Monitor)

Closes #88

## Test plan
- [ ] Run `caw` and verify `ps aux | grep caw` shows the process titled `caw` instead of `bun`
- [ ] Confirm no regressions in CLI behavior (subcommands, flags, TUI, server mode)