### PR TITLE
docs: update mcp-server README and tool counts

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -9,7 +9,7 @@ src/
 ├── config.ts        # resolveConfig, env var parsing, defaults
 ├── server.ts        # createMcpServer, startServer
 ├── tools/
-│   ├── workflow.ts    # 7 tools — create, get, list, set_plan, update_status, set_parallelism, get_summary
+│   ├── workflow.ts    # 13 tools — create, get, list, set_plan, update_status, set_parallelism, get_summary, lock, unlock, lock_info, add_repository, remove_repository, list_repositories
 │   ├── task.ts        # 4 tools — get, set_plan, update_status, replan
 │   ├── checkpoint.ts  # 2 tools — add, list
 │   ├── context.ts     # 1 tool  — task_load_context
@@ -19,6 +19,9 @@ src/
 │   ├── template.ts    # 3 tools — create, list, apply
 │   ├── agent.ts       # 9 tools — register, heartbeat, update, get, list, unregister, task_claim, task_release, task_get_available
 │   ├── messaging.ts   # 7 tools — send, broadcast, list, get, mark_read, archive, count_unread
+│   ├── replanning.ts  # 3 tools — add_task, remove_task, replan
+│   ├── spawner.ts     # 4 tools — workflow_start, workflow_suspend, workflow_resume, workflow_execution_status
+│   ├── lock-guard.ts  # utility for workflow lock enforcement (not tools)
 │   ├── types.ts       # defineTool, handleToolCall, ToolCallError
 │   └── index.ts       # registerAllTools barrel
 └── index.ts
@@ -26,11 +29,11 @@ src/
 
 ## Tool Categories
 
-43 tools across 10 categories:
+56 tools across 12 categories:
 
 | Category | Tools | Count |
 |---|---|---|
-| Workflow Lifecycle | `workflow_create`, `workflow_get`, `workflow_list`, `workflow_set_plan`, `workflow_update_status`, `workflow_set_parallelism`, `workflow_get_summary` | 7 |
+| Workflow Lifecycle | `workflow_create`, `workflow_get`, `workflow_list`, `workflow_set_plan`, `workflow_update_status`, `workflow_set_parallelism`, `workflow_get_summary`, `workflow_lock`, `workflow_unlock`, `workflow_lock_info`, `workflow_add_repository`, `workflow_remove_repository`, `workflow_list_repositories` | 13 |
 | Task Management | `task_get`, `task_set_plan`, `task_update_status`, `task_replan` | 4 |
 | Checkpoint Recording | `checkpoint_add`, `checkpoint_list` | 2 |
 | Context Loading | `task_load_context` | 1 |
@@ -40,6 +43,8 @@ src/
 | Template Management | `template_create`, `template_list`, `template_apply` | 3 |
 | Agent Management | `agent_register`, `agent_heartbeat`, `agent_update`, `agent_get`, `agent_list`, `agent_unregister`, `task_claim`, `task_release`, `task_get_available` | 9 |
 | Messaging | `message_send`, `message_broadcast`, `message_list`, `message_get`, `message_mark_read`, `message_archive`, `message_count_unread` | 7 |
+| Replanning | `workflow_add_task`, `workflow_remove_task`, `workflow_replan` | 3 |
+| Spawner | `workflow_start`, `workflow_suspend`, `workflow_resume`, `workflow_execution_status` | 4 |
 
 See [MCP Tools](../../docs/mcp-tools.md) for full parameter and return type definitions.
 
@@ -116,5 +121,6 @@ See [Error Handling](../../docs/error-handling.md) for the full error catalog.
 ## Dependencies
 
 - **@caw/core** — Database layer and services
+- **@caw/spawner** — Agent spawning and workflow execution
 - **@modelcontextprotocol/sdk** — MCP protocol implementation
 - **zod** — Schema validation for tool input


### PR DESCRIPTION
Closes #90

## Summary
- Updated tool count from 43 to 56 across 10 to 12 categories
- Added missing tool files to directory structure listing: `replanning.ts`, `spawner.ts`, `lock-guard.ts`
- Updated `workflow.ts` comment from 7 to 13 tools with the 6 new lock/repository tools
- Added Replanning (3 tools) and Spawner (4 tools) rows to the tool categories table
- Added `@caw/spawner` to the dependencies section

## Testing
- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] Tool count verified against `defineTool` calls across all tool files

🤖 Generated with [Claude Code](https://claude.com/claude-code)