### PR TITLE
feat: polish desktop UI — sidebar, panels, overflow fixes

### DIFF
--- a/apps/desktop/src/lib/components/AppSidebar.svelte
+++ b/apps/desktop/src/lib/components/AppSidebar.svelte
@@ -5,22 +5,26 @@ import SettingsIcon from '@lucide/svelte/icons/settings';
 import { page } from '$app/stores';
 import SidebarWorkflowItem from '$lib/components/SidebarWorkflowItem.svelte';
 import * as Sidebar from '$lib/components/ui/sidebar/index.js';
+import { useSidebar } from '$lib/components/ui/sidebar/index.js';
 import type { SidebarData } from '$lib/stores/sidebar-data.svelte';
 
 interface Props {
   data: SidebarData;
-  isTauri: boolean;
+  isTauri?: boolean;
 }
 
-const { data, isTauri }: Props = $props();
+const { data }: Props = $props();
 
+const sidebar = useSidebar();
+const isCollapsed = $derived(sidebar.state === 'collapsed');
 const pathname = $derived($page.url.pathname);
 </script>
 
 <Sidebar.Root collapsible="icon" variant="sidebar">
+  <Sidebar.Header class="pt-1 pb-0" />
   <Sidebar.Content>
     <!-- Top-level navigation -->
-    <Sidebar.Group class={isTauri ? 'pt-[38px]' : 'pt-2'}>
+    <Sidebar.Group>
       <Sidebar.GroupContent>
         <Sidebar.Menu>
           <Sidebar.MenuItem>
@@ -54,9 +58,23 @@ const pathname = $derived($page.url.pathname);
       </Sidebar.GroupContent>
     </Sidebar.Group>
 
+    <Sidebar.Separator class="mx-2" />
+
     <!-- Active Workflows -->
     <Sidebar.Group>
-      <Sidebar.GroupLabel>Active</Sidebar.GroupLabel>
+      <Sidebar.GroupLabel
+        class={isCollapsed
+          ? 'group-data-[collapsible=icon]:mt-0 group-data-[collapsible=icon]:opacity-100 justify-center'
+          : ''}
+      >
+        {#if isCollapsed}
+          <span class="flex size-5 items-center justify-center rounded-md bg-sidebar-accent text-[10px] font-semibold">
+            {data.activeWorkflows.length}
+          </span>
+        {:else}
+          Active
+        {/if}
+      </Sidebar.GroupLabel>
       <Sidebar.GroupContent>
         <Sidebar.Menu>
           {#each data.activeWorkflows as wf (wf.id)}
@@ -69,16 +87,18 @@ const pathname = $derived($page.url.pathname);
               {pathname}
             />
           {:else}
-            <Sidebar.MenuItem>
-              <span class="px-2 py-1 text-xs text-muted-foreground">No active workflows</span>
-            </Sidebar.MenuItem>
+            {#if !isCollapsed}
+              <Sidebar.MenuItem>
+                <span class="px-2 py-1 text-xs text-muted-foreground">No active workflows</span>
+              </Sidebar.MenuItem>
+            {/if}
           {/each}
         </Sidebar.Menu>
       </Sidebar.GroupContent>
     </Sidebar.Group>
   </Sidebar.Content>
 
-  <Sidebar.Footer>
+  <Sidebar.Footer class="border-t border-sidebar-border">
     <Sidebar.Menu>
       <Sidebar.MenuItem>
         <Sidebar.MenuButton

--- a/apps/desktop/src/lib/components/ExecutionPanel.svelte
+++ b/apps/desktop/src/lib/components/ExecutionPanel.svelte
@@ -2,27 +2,18 @@
 import PauseIcon from '@lucide/svelte/icons/pause';
 import PlayIcon from '@lucide/svelte/icons/play';
 import RotateCcwIcon from '@lucide/svelte/icons/rotate-ccw';
-import { api, type ProgressResult, type Workflow } from '$lib/api/client';
-import ProgressBar from '$lib/components/ProgressBar.svelte';
-import StatusBadge from '$lib/components/StatusBadge.svelte';
+import { api, type Workflow } from '$lib/api/client';
 import { Button } from '$lib/components/ui/button/index.js';
-import * as Card from '$lib/components/ui/card/index.js';
 
 interface Props {
   workflow: Workflow;
-  progress: ProgressResult | null;
-  agentCount: number;
   onRefresh: () => void;
 }
 
-const { workflow, progress, agentCount, onRefresh }: Props = $props();
+const { workflow, onRefresh }: Props = $props();
 
 let loading = $state<string | null>(null);
 let error = $state<string | null>(null);
-
-const completedTasks = $derived(
-  progress ? (progress.by_status['completed'] ?? 0) + (progress.by_status['skipped'] ?? 0) : 0,
-);
 
 const canStart = $derived(workflow.status === 'ready' || workflow.status === 'planning');
 const canPause = $derived(workflow.status === 'in_progress');
@@ -68,53 +59,26 @@ async function handleResume() {
 }
 </script>
 
-<Card.Root>
-  <Card.Content class="flex items-center gap-4 p-4">
-    <div class="flex items-center gap-2">
-      <StatusBadge status={workflow.status} />
-      {#if workflow.locked_by_session_id}
-        <span
-          class="rounded bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
-        >
-          Locked
-        </span>
-      {/if}
-    </div>
-
-    {#if progress}
-      <div class="flex-1 max-w-xs">
-        <ProgressBar completed={completedTasks} total={progress.total_tasks} />
-      </div>
-    {/if}
-
-    <div class="flex items-center gap-2 text-sm text-muted-foreground">
-      <span>{agentCount} agent{agentCount !== 1 ? 's' : ''}</span>
-    </div>
-
-    <div class="ml-auto flex items-center gap-2">
-      {#if canStart}
-        <Button size="sm" onclick={handleStart} disabled={loading === 'start'}>
-          <PlayIcon class="mr-1 size-4" />
-          Start
-        </Button>
-      {/if}
-      {#if canPause}
-        <Button size="sm" variant="outline" onclick={handlePause} disabled={loading === 'pause'}>
-          <PauseIcon class="mr-1 size-4" />
-          Pause
-        </Button>
-      {/if}
-      {#if canResume}
-        <Button size="sm" variant="outline" onclick={handleResume} disabled={loading === 'resume'}>
-          <RotateCcwIcon class="mr-1 size-4" />
-          Resume
-        </Button>
-      {/if}
-    </div>
-  </Card.Content>
-  {#if error}
-    <Card.Footer class="border-t px-4 py-2">
-      <p class="text-sm text-destructive">{error}</p>
-    </Card.Footer>
+<div class="flex items-center gap-2">
+  {#if canStart}
+    <Button size="sm" onclick={handleStart} disabled={loading === 'start'}>
+      <PlayIcon class="mr-1 size-4" />
+      Start
+    </Button>
   {/if}
-</Card.Root>
+  {#if canPause}
+    <Button size="sm" variant="outline" onclick={handlePause} disabled={loading === 'pause'}>
+      <PauseIcon class="mr-1 size-4" />
+      Pause
+    </Button>
+  {/if}
+  {#if canResume}
+    <Button size="sm" variant="outline" onclick={handleResume} disabled={loading === 'resume'}>
+      <RotateCcwIcon class="mr-1 size-4" />
+      Resume
+    </Button>
+  {/if}
+</div>
+{#if error}
+  <p class="text-sm text-destructive">{error}</p>
+{/if}

--- a/apps/desktop/src/lib/components/ui/sidebar/sidebar-content.svelte
+++ b/apps/desktop/src/lib/components/ui/sidebar/sidebar-content.svelte
@@ -15,7 +15,7 @@ let {
 	data-slot="sidebar-content"
 	data-sidebar="content"
 	class={cn(
-		"flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+		"flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden group-data-[collapsible=icon]:overflow-hidden",
 		className
 	)}
 	{...restProps}

--- a/apps/desktop/src/lib/components/ui/sidebar/sidebar-inset.svelte
+++ b/apps/desktop/src/lib/components/ui/sidebar/sidebar-inset.svelte
@@ -14,7 +14,7 @@ let {
 	bind:this={ref}
 	data-slot="sidebar-inset"
 	class={cn(
-		"bg-background relative flex w-full flex-1 flex-col",
+		"bg-background relative flex min-w-0 w-full flex-1 flex-col",
 		"md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ms-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ms-2",
 		className
 	)}

--- a/apps/desktop/src/lib/components/ui/sidebar/sidebar.svelte
+++ b/apps/desktop/src/lib/components/ui/sidebar/sidebar.svelte
@@ -81,7 +81,7 @@ const sidebar = useSidebar();
 		<div
 			data-slot="sidebar-container"
 			class={cn(
-				"fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+				"fixed top-12 bottom-0 z-10 hidden h-[calc(100svh-3rem)] w-(--sidebar-width) overflow-hidden transition-[left,right,width] duration-200 ease-linear md:flex",
 				side === "left"
 					? "start-0 group-data-[collapsible=offcanvas]:start-[calc(var(--sidebar-width)*-1)]"
 					: "end-0 group-data-[collapsible=offcanvas]:end-[calc(var(--sidebar-width)*-1)]",

--- a/apps/desktop/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/apps/desktop/src/lib/components/ui/tabs/tabs-content.svelte
@@ -12,6 +12,6 @@ let {
 <TabsPrimitive.Content
 	bind:ref
 	data-slot="tabs-content"
-	class={cn("flex-1 outline-none", className)}
+	class={cn("flex-1 min-w-0 outline-none", className)}
 	{...restProps}
 />

--- a/apps/desktop/src/routes/(app)/+page.svelte
+++ b/apps/desktop/src/routes/(app)/+page.svelte
@@ -20,20 +20,9 @@ let loading = $state(true);
 let error = $state<string | null>(null);
 let showAll = $state(false);
 let showCreateDialog = $state(false);
-let searchQuery = $state('');
 let pollInterval: ReturnType<typeof setInterval>;
 
 const activeStatuses = 'planning,ready,in_progress,paused,awaiting_merge';
-
-const filteredWorkflows = $derived(
-  searchQuery
-    ? workflows.filter(
-        (w) =>
-          w.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-          w.id.toLowerCase().includes(searchQuery.toLowerCase()),
-      )
-    : workflows,
-);
 
 async function loadWorkflows() {
   try {
@@ -87,15 +76,9 @@ $effect(() => {
 });
 </script>
 
-<div class="px-5 py-4 space-y-4">
+<div class="min-w-0 px-5 py-4 space-y-4">
   <div class="flex items-center justify-between">
     <div class="flex items-center gap-2">
-      <input
-        type="text"
-        placeholder="Search..."
-        bind:value={searchQuery}
-        class="h-9 w-48 rounded-md border border-input bg-background px-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-      />
       <Button variant="outline" size="sm" onclick={() => { showAll = !showAll; loadWorkflows(); }}>
         {showAll ? 'All' : 'Active'}
       </Button>
@@ -121,13 +104,11 @@ $effect(() => {
     <Card.Root class="border-destructive">
       <Card.Content class="p-4 text-sm text-destructive">{error}</Card.Content>
     </Card.Root>
-  {:else if filteredWorkflows.length === 0}
+  {:else if workflows.length === 0}
     <EmptyState
       icon={ListIcon}
       title="No workflows found"
-      description={searchQuery
-        ? 'Try a different search term.'
-        : 'Create a workflow via MCP, the CLI, or the button above.'}
+      description="Create a workflow via MCP, the CLI, or the button above."
     />
   {:else}
     <Table.Root>
@@ -141,7 +122,7 @@ $effect(() => {
         </Table.Row>
       </Table.Header>
       <Table.Body>
-        {#each filteredWorkflows as wf}
+        {#each workflows as wf}
           <Table.Row class="cursor-pointer">
             <Table.Cell>
               <a

--- a/apps/desktop/src/routes/(app)/templates/+page.svelte
+++ b/apps/desktop/src/routes/(app)/templates/+page.svelte
@@ -17,7 +17,6 @@ import { wsStore } from '$lib/stores/ws';
 let templates = $state<WorkflowTemplate[]>([]);
 let loading = $state(true);
 let error = $state<string | null>(null);
-let searchQuery = $state('');
 let sourceFilter = $state<'all' | 'file' | 'db'>('all');
 let expandedCards = $state<Set<string>>(new Set());
 let pollInterval: ReturnType<typeof setInterval>;
@@ -48,12 +47,6 @@ const filteredTemplates = $derived.by(() => {
     result = result.filter((t) => t.source?.startsWith('file:'));
   } else if (sourceFilter === 'db') {
     result = result.filter((t) => !t.source || t.source === 'db');
-  }
-  if (searchQuery) {
-    const q = searchQuery.toLowerCase();
-    result = result.filter(
-      (t) => t.name.toLowerCase().includes(q) || (t.description ?? '').toLowerCase().includes(q),
-    );
   }
   return result;
 });
@@ -129,12 +122,6 @@ $effect(() => {
 
 <div class="px-5 py-4 space-y-4">
   <div class="flex items-center gap-2">
-    <input
-      type="text"
-      placeholder="Search templates..."
-      bind:value={searchQuery}
-      class="h-9 w-48 rounded-md border border-input bg-background px-3 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
-    />
     <div class="flex rounded-md border border-input">
       {#each [['all', 'All'], ['file', 'File'], ['db', 'DB']] as [value, label]}
         <button
@@ -172,8 +159,8 @@ $effect(() => {
     <EmptyState
       icon={FileTextIcon}
       title="No templates found"
-      description={searchQuery || sourceFilter !== 'all'
-        ? 'Try adjusting your search or filter.'
+      description={sourceFilter !== 'all'
+        ? 'Try adjusting your filter.'
         : 'Create templates via MCP tools or add .yaml files to .caw/templates/.'}
     />
   {:else}


### PR DESCRIPTION
## Summary

- Improve sidebar collapsed state with active workflow count badge and visual refinements (separator, footer border, header offset)
- Simplify `ExecutionPanel` to action buttons only, removing card wrapper and redundant progress/agent props
- Remove inline search inputs from workflows and templates pages (will be replaced by command palette search)
- Fix overflow issues across sidebar content, sidebar inset, and tabs content with `min-w-0` and `overflow-x-hidden`

## Test plan

- [ ] Verify sidebar collapses correctly and shows workflow count badge
- [ ] Verify sidebar sits below the header bar (not overlapping)
- [ ] Verify ExecutionPanel start/pause/resume buttons work on workflow detail page
- [ ] Verify workflows page renders without search input, active/all toggle still works
- [ ] Verify templates page renders without search input, source filter still works
- [ ] Verify no horizontal overflow on narrow viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)