### PR TITLE
feat: simplify config system, add agent parallelism, type source_type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Desktop users have full access to the local Bun runtime, git, and all CLI comman
 Web sessions run in a sandboxed Linux environment. Key differences from desktop:
 
 - **No persistent daemon**: The daemon mode (`caw run --detach`) will not persist between sessions. Prefer `--no-watch` or direct MCP server mode (`caw --server`) for headless operation.
-- **No global `~/.caw/` directory across sessions**: Use per-repo mode (`--db .caw/workflows.db`) to keep data within the repo.
+- **No global `~/.caw/` directory across sessions**: The database is always stored at `~/.caw/workflows.db`. Use `--db` flag to override if needed.
 - **Bun is available**: The runtime environment includes Bun, so all build/test/lint commands work as documented.
 - **Git is available**: Standard git operations work. Push requires proper remote configuration.
 - **Use CLI mode**: On web, use `caw --server` (headless MCP) or the CLI subcommands (`caw run`, `caw init`, etc.).
@@ -151,7 +151,7 @@ The `caw` binary (`apps/cli/src/bin/cli.ts`) supports these modes:
 ```bash
 caw --server                     # Headless MCP server (stdio transport)
 caw --server --transport http    # Combined server: MCP + REST API + WebSocket (port 3100)
-caw init [--yes] [--global]      # Initialize caw in repo or globally
+caw init [--yes]                 # Initialize caw (~/.caw/ config, templates)
 caw setup claude-code            # Configure Claude Code MCP integration
 caw run <workflow_id>            # Execute a workflow
 caw run --prompt "..."           # Create + plan + run from a prompt
@@ -182,7 +182,7 @@ caw --list-templates             # List available templates
 
 ### Database Layer (`packages/core/src/db/`)
 
-- **`connection.ts`** — `createConnection(dbPath)` creates a SQLite connection with WAL mode, foreign keys, and 5s busy timeout. `getDbPath(mode, repoPath?)` resolves to `~/.caw/workflows.db` (global) or `{repoPath}/.caw/workflows.db` (per-repo).
+- **`connection.ts`** — `createConnection(dbPath)` creates a SQLite connection with WAL mode, foreign keys, and 5s busy timeout. `getDbPath()` always returns `~/.caw/workflows.db` (global database).
 - **`migrations/`** — Numbered migration files (001–004) export SQL as string constants (no filesystem reads). `runMigrations(db)` applies unapplied migrations in transactions. The `schema_migrations` table is managed by the runner, not included in migration SQL.
 
 ### Migrations
@@ -246,11 +246,18 @@ One file per entity, matching the SQLite schema exactly. Barrel-exported through
 
 ### Config System (`packages/core/src/config/`)
 
-Zod-validated configuration loaded from `.caw/config.json` (per-repo) or `~/.caw/config.json` (global). Schema defined in `config/schema.ts`:
+Zod-validated configuration loaded from `~/.caw/config.json` (global) with optional `.caw/config.json` (per-repo override). Schema defined in `config/schema.ts`:
 
 ```typescript
-{ transport?: 'stdio' | 'http', port?: number, dbMode?: 'global' | 'per-repo', agent?: { runtime?, autoSetup? } }
+{
+  transport?: 'stdio' | 'http',
+  port?: number,
+  agent?: { runtime?: 'claude-code', autoSetup?, maxParallelAgents?, agentsPerWorkflow? },
+  pr?: { pollEnabled?, pollInterval?, cycle?, mergeMethod?, ciTimeout?, noReview? }
+}
 ```
+
+`AGENT_DEFAULTS`: `{ runtime: 'claude-code', maxParallelAgents: 10, agentsPerWorkflow: 3 }`
 
 ---
 

--- a/apps/cli/src/bin/cli.ts
+++ b/apps/cli/src/bin/cli.ts
@@ -6,7 +6,7 @@ import { createConnection, getDbPath, runMigrations, templateResolver } from '@c
 
 function printUsage(): void {
   console.log(`Usage: caw [options] [description]
-       caw init [--yes] [--global]
+       caw init [--yes]
        caw setup claude-code [--print] [--mcp-only] [--claude-md-only]
        caw run <workflow_id> [options]
        caw run --prompt "..." [options]
@@ -18,15 +18,13 @@ Options:
   --transport <type>    MCP transport: stdio | http (default: stdio)
                         HTTP mode also serves REST API + WebSocket
   --port <number>       HTTP port (default: 3100)
-  --db <path>           Database file path
   --template <name>     Create workflow from named template (requires description)
   --list-templates      List available workflow templates
   -h, --help            Show this help message
 
 Commands:
-  init                  Initialize caw in the current repository
+  init                  Initialize caw (~/.caw/ config, templates)
     --yes, -y           Skip prompts, use defaults
-    --global            Initialize global config (~/.caw/) instead of per-repo
 
   setup claude-code     Configure Claude Code to use caw
     --print             Print what would be added without modifying files
@@ -59,7 +57,6 @@ if (subcommand === 'init') {
     args: process.argv.slice(3),
     options: {
       yes: { type: 'boolean', short: 'y', default: false },
-      global: { type: 'boolean', default: false },
       help: { type: 'boolean', short: 'h', default: false },
     },
     strict: true,
@@ -74,7 +71,6 @@ if (subcommand === 'init') {
   const { runInit } = await import('../commands/init');
   await runInit({
     yes: initValues.yes,
-    global: initValues.global,
     repoPath: process.cwd(),
   });
   process.exit(0);
@@ -108,6 +104,22 @@ if (subcommand === 'setup') {
     claudeMdOnly: setupValues['claude-md-only'],
   });
   process.exit(0);
+}
+
+// --- Initialization check (all commands except init/setup/--help/--db) ---
+{
+  const rawArgs = process.argv.slice(2);
+  const skipInit = rawArgs.includes('--help') || rawArgs.includes('-h') || rawArgs.includes('--db');
+  if (!skipInit) {
+    const { existsSync } = await import('node:fs');
+    const { homedir } = await import('node:os');
+    const { join } = await import('node:path');
+    const globalConfig = join(homedir(), '.caw', 'config.json');
+    if (!existsSync(globalConfig)) {
+      console.error("caw is not initialized. Run 'caw init' to set up.");
+      process.exit(1);
+    }
+  }
 }
 
 if (subcommand === 'run') {
@@ -152,7 +164,10 @@ Options:
     process.exit(0);
   }
 
-  const runDbPath = runValues.db ?? getDbPath('per-repo', process.cwd());
+  if (runValues.db) {
+    console.warn('[caw] --db is deprecated. Database is always stored at ~/.caw/workflows.db.');
+  }
+  const runDbPath = runValues.db ?? getDbPath();
   const runDb = createConnection(runDbPath);
   runMigrations(runDb);
 
@@ -246,7 +261,10 @@ Options:
     process.exit(prValues.help ? 0 : 1);
   }
 
-  const prDbPath = prValues.db ?? getDbPath('per-repo', process.cwd());
+  if (prValues.db) {
+    console.warn('[caw] --db is deprecated. Database is always stored at ~/.caw/workflows.db.');
+  }
+  const prDbPath = prValues.db ?? getDbPath();
   const prDb = createConnection(prDbPath);
   runMigrations(prDb);
 
@@ -327,7 +345,10 @@ Options:
     process.exit(workValues.help ? 0 : 1);
   }
 
-  const workDbPath = workValues.db ?? getDbPath('per-repo', process.cwd());
+  if (workValues.db) {
+    console.warn('[caw] --db is deprecated. Database is always stored at ~/.caw/workflows.db.');
+  }
+  const workDbPath = workValues.db ?? getDbPath();
   const workDb = createConnection(workDbPath);
   runMigrations(workDb);
 
@@ -398,7 +419,10 @@ const repoRoot = (() => {
     return process.cwd();
   }
 })();
-const dbPath = values.db ?? getDbPath('per-repo', repoRoot);
+if (values.db) {
+  console.warn('[caw] --db is deprecated. Database is always stored at ~/.caw/workflows.db.');
+}
+const dbPath = values.db ?? getDbPath();
 const db = createConnection(dbPath);
 runMigrations(db);
 

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,20 +1,19 @@
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
-import type { CawConfig, DbMode } from '@caw/core';
-import { EXAMPLE_TEMPLATES, ensureGitignore, stringifyYaml, writeConfig } from '@caw/core';
+import type { CawConfig } from '@caw/core';
+import { EXAMPLE_TEMPLATES, stringifyYaml, writeConfig } from '@caw/core';
 import { setupClaudeCode } from './setup-claude-code';
 
 export interface InitOptions {
   yes?: boolean;
-  global?: boolean;
   repoPath: string;
 }
 
 interface InitResult {
   configPath: string;
   config: CawConfig;
-  gitignoreUpdated: boolean;
   claudeCodeSetup: boolean;
   messages: string[];
 }
@@ -58,38 +57,24 @@ async function runInteractive(repoPath: string, configDir: string): Promise<Init
         return {
           configPath,
           config: {},
-          gitignoreUpdated: false,
           claudeCodeSetup: false,
           messages,
         };
       }
     }
 
-    // Database mode
-    const modeAnswer = await prompt(rl, 'Database mode? (per-repo/global) [per-repo] ');
-    const dbMode: DbMode = modeAnswer.trim().toLowerCase() === 'global' ? 'global' : 'per-repo';
-
     // Claude Code setup
     const setupAnswer = await prompt(rl, 'Set up Claude Code integration? (Y/n) ');
     const doSetup = setupAnswer.trim().toLowerCase() !== 'n';
 
     // Write config
-    const config: CawConfig = { dbMode };
+    const config: CawConfig = {};
     if (doSetup) {
-      config.agent = { runtime: 'claude_code', autoSetup: true };
+      config.agent = { runtime: 'claude-code', autoSetup: true };
     }
 
     writeConfig(configPath, config);
     messages.push(`Created ${configPath}`);
-
-    // Gitignore (only for per-repo)
-    let gitignoreUpdated = false;
-    if (dbMode === 'per-repo') {
-      gitignoreUpdated = ensureGitignore(repoPath, '.caw/');
-      if (gitignoreUpdated) {
-        messages.push('Added .caw/ to .gitignore');
-      }
-    }
 
     // Claude Code setup
     let claudeCodeSetup = false;
@@ -102,30 +87,21 @@ async function runInteractive(repoPath: string, configDir: string): Promise<Init
     // Write example templates
     messages.push(...writeExampleTemplates(configDir));
 
-    return { configPath, config, gitignoreUpdated, claudeCodeSetup, messages };
+    return { configPath, config, claudeCodeSetup, messages };
   } finally {
     rl.close();
   }
 }
 
-function runNonInteractive(repoPath: string, configDir: string, isGlobal: boolean): InitResult {
+function runNonInteractive(repoPath: string, configDir: string): InitResult {
   const messages: string[] = [];
   const configPath = join(configDir, 'config.json');
   const config: CawConfig = {
-    dbMode: isGlobal ? 'global' : 'per-repo',
-    agent: { runtime: 'claude_code', autoSetup: true },
+    agent: { runtime: 'claude-code', autoSetup: true },
   };
 
   writeConfig(configPath, config);
   messages.push(`Created ${configPath}`);
-
-  let gitignoreUpdated = false;
-  if (!isGlobal) {
-    gitignoreUpdated = ensureGitignore(repoPath, '.caw/');
-    if (gitignoreUpdated) {
-      messages.push('Added .caw/ to .gitignore');
-    }
-  }
 
   const result = setupClaudeCode({ repoPath });
   messages.push(...result.messages);
@@ -134,23 +110,18 @@ function runNonInteractive(repoPath: string, configDir: string, isGlobal: boolea
   // Write example templates
   messages.push(...writeExampleTemplates(configDir));
 
-  return { configPath, config, gitignoreUpdated, claudeCodeSetup, messages };
+  return { configPath, config, claudeCodeSetup, messages };
 }
 
 export async function runInit(opts: InitOptions): Promise<void> {
   const { repoPath } = opts;
 
-  let configDir: string;
-  if (opts.global) {
-    const { homedir } = await import('node:os');
-    configDir = join(homedir(), '.caw');
-  } else {
-    configDir = join(repoPath, '.caw');
-  }
+  // Always target ~/.caw/
+  const configDir = join(homedir(), '.caw');
 
   let result: InitResult;
   if (opts.yes) {
-    result = runNonInteractive(repoPath, configDir, opts.global ?? false);
+    result = runNonInteractive(repoPath, configDir);
   } else {
     result = await runInteractive(repoPath, configDir);
   }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -7,23 +7,8 @@ use window_vibrancy::{apply_vibrancy, NSVisualEffectMaterial};
 
 struct SidecarState(std::sync::Mutex<Option<tauri_plugin_shell::process::CommandChild>>);
 
-/// Resolve the database path for the sidecar.
-/// 1. Try `git rev-parse --show-toplevel` → `<repo_root>/.caw/workflows.db`
-/// 2. Fall back to `~/.caw/workflows.db` (global mode)
+/// Resolve the database path for the sidecar — always global ~/.caw/workflows.db.
 fn resolve_db_path() -> String {
-    if let Ok(output) = std::process::Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-    {
-        if output.status.success() {
-            let repo_root = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !repo_root.is_empty() {
-                return format!("{repo_root}/.caw/workflows.db");
-            }
-        }
-    }
-
-    // Fall back to global ~/.caw/workflows.db
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
     format!("{home}/.caw/workflows.db")
 }
@@ -139,6 +124,23 @@ async fn restart_server(app: tauri::AppHandle) -> Result<serde_json::Value, Stri
 }
 
 #[tauri::command]
+async fn run_init(app: tauri::AppHandle) -> Result<serde_json::Value, String> {
+    let sidecar = app.shell().sidecar("caw").map_err(|e| e.to_string())?;
+    let output = sidecar
+        .args(["init", "--yes"])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to run caw init: {e}"))?;
+
+    if output.status.success() {
+        Ok(serde_json::json!({ "success": true }))
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        Err(format!("caw init failed: {stderr}"))
+    }
+}
+
+#[tauri::command]
 async fn stop_server(app: tauri::AppHandle) -> Result<serde_json::Value, String> {
     let state = app.state::<SidecarState>();
     let mut guard = state.0.lock().map_err(|e| e.to_string())?;
@@ -153,7 +155,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
-        .invoke_handler(tauri::generate_handler![server_status, restart_server, stop_server])
+        .invoke_handler(tauri::generate_handler![server_status, restart_server, stop_server, run_init])
         .setup(|app| {
             // Build native macOS menu bar
             build_menu(app)?;

--- a/apps/desktop/src/lib/api/client.ts
+++ b/apps/desktop/src/lib/api/client.ts
@@ -30,11 +30,13 @@ async function request<T>(method: string, path: string, body?: unknown): Promise
 
 // --- Workflows ---
 
+export type WorkflowSourceType = 'prompt' | 'github_issue' | 'spec_file' | 'template' | 'custom';
+
 export interface WorkflowSummary {
   id: string;
   name: string;
   status: string;
-  source_type: string;
+  source_type: WorkflowSourceType;
   created_at: number;
   updated_at: number;
 }
@@ -42,7 +44,7 @@ export interface WorkflowSummary {
 export interface Workflow {
   id: string;
   name: string;
-  source_type: string;
+  source_type: WorkflowSourceType;
   source_ref: string | null;
   source_content: string | null;
   status: string;
@@ -548,6 +550,10 @@ export const api = {
   },
 
   // Setup
+  async getInitStatus() {
+    return request<{ initialized: boolean }>('GET', '/api/setup/status');
+  },
+
   async getDiagnostics() {
     return request<DiagnosticsResponse>('GET', '/api/setup/diagnostics');
   },

--- a/apps/desktop/src/routes/(app)/+layout.svelte
+++ b/apps/desktop/src/routes/(app)/+layout.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
+import AlertTriangleIcon from '@lucide/svelte/icons/alert-triangle';
 import XIcon from '@lucide/svelte/icons/x';
 import { onDestroy, onMount, setContext } from 'svelte';
 import { page } from '$app/stores';
+import { api } from '$lib/api/client';
 import AppSidebar from '$lib/components/AppSidebar.svelte';
 import LiveIndicator from '$lib/components/LiveIndicator.svelte';
 import ServerPanel from '$lib/components/panels/ServerPanel.svelte';
@@ -16,6 +18,9 @@ const { children } = $props();
 
 let isTauri = $state(false);
 let serverAction = $state<'restarting' | 'stopping' | null>(null);
+let initChecked = $state(false);
+let initialized = $state(true);
+let initRunning = $state(false);
 
 const sidebarData = new SidebarData();
 const isSettings = $derived($page.url.pathname.startsWith('/settings'));
@@ -92,8 +97,34 @@ $effect(() => {
   }
 });
 
+async function checkInit() {
+  try {
+    const result = await api.getInitStatus();
+    initialized = result.data.initialized;
+  } catch {
+    // Server may not be ready yet
+  } finally {
+    initChecked = true;
+  }
+}
+
+async function handleInit() {
+  if (initRunning || !isTauri) return;
+  initRunning = true;
+  try {
+    const { invoke } = await import('@tauri-apps/api/core');
+    await invoke('run_init');
+    await checkInit();
+  } catch {
+    // Init may have failed
+  } finally {
+    initRunning = false;
+  }
+}
+
 onMount(() => {
   sidebarData.startPolling();
+  checkInit();
 });
 
 onDestroy(() => {
@@ -142,6 +173,17 @@ $effect(() => {
     <Sidebar.Inset>
       <div class="flex flex-1 min-w-0 overflow-hidden">
         <div class="flex-1 overflow-auto overscroll-none min-w-0">
+          {#if initChecked && !initialized}
+            <div class="flex items-center gap-3 border-b bg-amber-50 px-4 py-2.5 text-sm text-amber-800 dark:bg-amber-950/50 dark:text-amber-200">
+              <AlertTriangleIcon class="size-4 shrink-0" />
+              <span class="flex-1">caw is not initialized. Run <code class="rounded bg-amber-100 px-1 dark:bg-amber-900">caw init</code> in your terminal to set up.</span>
+              {#if isTauri}
+                <Button size="sm" variant="outline" onclick={handleInit} disabled={initRunning}>
+                  {initRunning ? 'Initializing...' : 'Initialize'}
+                </Button>
+              {/if}
+            </div>
+          {/if}
           {@render children()}
         </div>
         {#if rightPanel.visible && rightPanel.component}

--- a/apps/desktop/src/routes/(app)/settings/+page.svelte
+++ b/apps/desktop/src/routes/(app)/settings/+page.svelte
@@ -29,9 +29,10 @@ let configError = $state<string | null>(null);
 let saving = $state(false);
 let transport = $state('stdio');
 let port = $state('3100');
-let dbMode = $state('global');
 let agentRuntime = $state('claude-code');
 let agentAutoSetup = $state(true);
+let maxParallelAgents = $state('10');
+let agentsPerWorkflow = $state('3');
 
 // === Repositories tab state ===
 let repositories = $state<Repository[]>([]);
@@ -68,10 +69,18 @@ async function loadConfig() {
     config = result.data;
     transport = String(config.config.transport ?? 'stdio');
     port = String(config.config.port ?? '3100');
-    dbMode = String(config.config.dbMode ?? 'global');
-    const agent = config.config.agent as { runtime?: string; autoSetup?: boolean } | undefined;
+    const agent = config.config.agent as
+      | {
+          runtime?: string;
+          autoSetup?: boolean;
+          maxParallelAgents?: number;
+          agentsPerWorkflow?: number;
+        }
+      | undefined;
     agentRuntime = agent?.runtime ?? 'claude-code';
     agentAutoSetup = agent?.autoSetup ?? true;
+    maxParallelAgents = String(agent?.maxParallelAgents ?? 10);
+    agentsPerWorkflow = String(agent?.agentsPerWorkflow ?? 3);
   } catch (err) {
     configError = err instanceof Error ? err.message : 'Failed to fetch configuration';
   } finally {
@@ -85,8 +94,12 @@ async function handleSave() {
     await api.updateConfig({
       transport,
       port: Number(port),
-      dbMode,
-      agent: { runtime: agentRuntime, autoSetup: agentAutoSetup },
+      agent: {
+        runtime: agentRuntime,
+        autoSetup: agentAutoSetup,
+        maxParallelAgents: Number(maxParallelAgents),
+        agentsPerWorkflow: Number(agentsPerWorkflow),
+      },
     });
     toast.success('Configuration saved');
   } catch (err) {
@@ -187,8 +200,7 @@ const actionableHints: Record<string, string> = {
   Database: 'Run `caw init` to create the database',
   'MCP Server': 'Run `caw setup claude-code` to configure MCP integration',
   'CLAUDE.md': 'Add a CLAUDE.md file with caw integration section',
-  'Config file': 'Run `caw init` to create the config file',
-  Gitignore: 'Add `.caw/` to your .gitignore file',
+  'Config file': 'Run `caw init` to create ~/.caw/config.json',
 };
 
 onMount(() => {
@@ -250,17 +262,6 @@ $effect(() => {
                 <Input id="port" type="number" bind:value={port} />
               </div>
             </div>
-            <div class="space-y-2">
-              <Label for="dbMode">Database Mode</Label>
-              <select
-                id="dbMode"
-                bind:value={dbMode}
-                class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-              >
-                <option value="global">global</option>
-                <option value="per-repo">per-repo</option>
-              </select>
-            </div>
           </Card.Content>
         </Card.Root>
 
@@ -278,9 +279,17 @@ $effect(() => {
                 class="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
               >
                 <option value="claude-code">claude-code</option>
-                <option value="codex">codex</option>
-                <option value="opencode">opencode</option>
               </select>
+            </div>
+            <div class="grid gap-4 sm:grid-cols-2">
+              <div class="space-y-2">
+                <Label for="maxParallelAgents">Max Parallel Agents (global)</Label>
+                <Input id="maxParallelAgents" type="number" min="1" max="50" bind:value={maxParallelAgents} />
+              </div>
+              <div class="space-y-2">
+                <Label for="agentsPerWorkflow">Agents Per Workflow</Label>
+                <Input id="agentsPerWorkflow" type="number" min="1" max="20" bind:value={agentsPerWorkflow} />
+              </div>
             </div>
             <div class="flex items-center gap-3">
               <input

--- a/apps/desktop/src/routes/(app)/templates/+page.svelte
+++ b/apps/desktop/src/routes/(app)/templates/+page.svelte
@@ -4,7 +4,7 @@ import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
 import FileTextIcon from '@lucide/svelte/icons/file-text';
 import PlayIcon from '@lucide/svelte/icons/play';
 import { onDestroy, onMount } from 'svelte';
-import { api, type WorkflowTemplate } from '$lib/api/client';
+import { api, type Repository, type WorkflowTemplate } from '$lib/api/client';
 import ApplyTemplateDialog from '$lib/components/ApplyTemplateDialog.svelte';
 import EmptyState from '$lib/components/EmptyState.svelte';
 import { Badge } from '$lib/components/ui/badge/index.js';
@@ -15,6 +15,7 @@ import { commandStore } from '$lib/stores/command';
 import { wsStore } from '$lib/stores/ws';
 
 let templates = $state<WorkflowTemplate[]>([]);
+let repositories = $state<Repository[]>([]);
 let loading = $state(true);
 let error = $state<string | null>(null);
 let sourceFilter = $state<'all' | 'file' | 'db'>('all');
@@ -63,6 +64,15 @@ async function loadTemplates() {
   }
 }
 
+async function loadRepositories() {
+  try {
+    const result = await api.listRepositories();
+    repositories = result.data;
+  } catch {
+    // Non-critical
+  }
+}
+
 function toggleExpanded(id: string) {
   const next = new Set(expandedCards);
   if (next.has(id)) {
@@ -95,6 +105,7 @@ function sourceBadgeClass(source?: string): string {
 
 onMount(() => {
   loadTemplates();
+  loadRepositories();
   pollInterval = setInterval(loadTemplates, 5000);
 
   commandStore.registerActions([
@@ -241,6 +252,22 @@ $effect(() => {
     </div>
   {/if}
 </div>
+
+{#if repositories.length > 0}
+  <div class="px-5 pb-4 space-y-3">
+    <h3 class="text-sm font-semibold text-muted-foreground">Registered Repositories</h3>
+    <div class="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+      {#each repositories as repo}
+        <Card.Root>
+          <Card.Content class="p-3">
+            <p class="text-sm font-medium">{repo.name}</p>
+            <p class="text-xs text-muted-foreground font-mono truncate">{repo.path}</p>
+          </Card.Content>
+        </Card.Root>
+      {/each}
+    </div>
+  </div>
+{/if}
 
 <ApplyTemplateDialog
   template={applyTemplate}

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -3,13 +3,14 @@ export type { LoadConfigResult } from './loader';
 export { getConfigPaths, loadConfig, mergeConfigs, readConfigFile, writeConfig } from './loader';
 export type {
   AgentConfig,
+  AgentRuntime,
   CawConfig,
   CycleMode,
-  DbMode,
   MergeMethod,
   PrConfig,
   TransportType,
+  WorkflowSourceType,
 } from './schema';
-export { cawConfigSchema } from './schema';
+export { AGENT_DEFAULTS, cawConfigSchema } from './schema';
 export type { ValidationResult } from './validate';
 export { validateConfig } from './validate';

--- a/packages/core/src/config/loader.test.ts
+++ b/packages/core/src/config/loader.test.ts
@@ -20,18 +20,18 @@ describe('mergeConfigs', () => {
   });
 
   test('preserves earlier values when later config omits them', () => {
-    const result = mergeConfigs({ transport: 'http', port: 8080 }, { dbMode: 'global' });
+    const result = mergeConfigs({ transport: 'http', port: 8080 }, { agent: { autoSetup: true } });
     expect(result.transport).toBe('http');
     expect(result.port).toBe(8080);
-    expect(result.dbMode).toBe('global');
+    expect(result.agent?.autoSetup).toBe(true);
   });
 
   test('deep merges agent config', () => {
     const result = mergeConfigs(
-      { agent: { runtime: 'claude_code' } },
+      { agent: { runtime: 'claude-code' } },
       { agent: { autoSetup: true } },
     );
-    expect(result.agent).toEqual({ runtime: 'claude_code', autoSetup: true });
+    expect(result.agent).toEqual({ runtime: 'claude-code', autoSetup: true });
   });
 });
 
@@ -144,10 +144,10 @@ describe('writeConfig', () => {
 
   test('creates parent directories', () => {
     const configPath = join(tmpDir, 'deep', 'nested', 'config.json');
-    writeConfig(configPath, { dbMode: 'global' });
+    writeConfig(configPath, { transport: 'http' });
     expect(existsSync(configPath)).toBe(true);
     const parsed = JSON.parse(readFileSync(configPath, 'utf-8'));
-    expect(parsed.dbMode).toBe('global');
+    expect(parsed.transport).toBe('http');
   });
 
   test('writes pretty-printed JSON with trailing newline', () => {

--- a/packages/core/src/config/loader.ts
+++ b/packages/core/src/config/loader.ts
@@ -32,7 +32,6 @@ export function mergeConfigs(...configs: CawConfig[]): CawConfig {
   for (const config of configs) {
     if (config.transport !== undefined) result.transport = config.transport;
     if (config.port !== undefined) result.port = config.port;
-    if (config.dbMode !== undefined) result.dbMode = config.dbMode;
     if (config.agent !== undefined) {
       result.agent = { ...result.agent, ...config.agent };
     }

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -1,11 +1,22 @@
 import { z } from 'zod';
 
 export const transportTypeSchema = z.enum(['stdio', 'http']);
-export const dbModeSchema = z.enum(['global', 'per-repo']);
+
+export const agentRuntimeSchema = z.enum(['claude-code']);
+
+export const workflowSourceTypeSchema = z.enum([
+  'prompt',
+  'github_issue',
+  'spec_file',
+  'template',
+  'custom',
+]);
 
 export const agentConfigSchema = z.object({
-  runtime: z.string().optional(),
+  runtime: agentRuntimeSchema.optional(),
   autoSetup: z.boolean().optional(),
+  maxParallelAgents: z.number().int().min(1).max(50).optional(),
+  agentsPerWorkflow: z.number().int().min(1).max(20).optional(),
 });
 
 export const cycleModeSchema = z.enum(['auto', 'hitl', 'off']);
@@ -23,13 +34,19 @@ export const prConfigSchema = z.object({
 export const cawConfigSchema = z.object({
   transport: transportTypeSchema.optional(),
   port: z.number().int().min(1).max(65535).optional(),
-  dbMode: dbModeSchema.optional(),
   agent: agentConfigSchema.optional(),
   pr: prConfigSchema.optional(),
 });
 
+export const AGENT_DEFAULTS = {
+  runtime: 'claude-code',
+  maxParallelAgents: 10,
+  agentsPerWorkflow: 3,
+} as const;
+
 export type TransportType = z.infer<typeof transportTypeSchema>;
-export type DbMode = z.infer<typeof dbModeSchema>;
+export type AgentRuntime = z.infer<typeof agentRuntimeSchema>;
+export type WorkflowSourceType = z.infer<typeof workflowSourceTypeSchema>;
 export type AgentConfig = z.infer<typeof agentConfigSchema>;
 export type CycleMode = z.infer<typeof cycleModeSchema>;
 export type MergeMethod = z.infer<typeof mergeMethodSchema>;

--- a/packages/core/src/config/validate.test.ts
+++ b/packages/core/src/config/validate.test.ts
@@ -13,15 +13,13 @@ describe('validateConfig', () => {
     const result = validateConfig({
       transport: 'http',
       port: 3100,
-      dbMode: 'global',
-      agent: { runtime: 'claude_code', autoSetup: true },
+      agent: { runtime: 'claude-code', autoSetup: true },
     });
     expect(result.valid).toBe(true);
     expect(result.config).toEqual({
       transport: 'http',
       port: 3100,
-      dbMode: 'global',
-      agent: { runtime: 'claude_code', autoSetup: true },
+      agent: { runtime: 'claude-code', autoSetup: true },
     });
     expect(result.warnings).toEqual([]);
   });
@@ -69,16 +67,20 @@ describe('validateConfig', () => {
     expect(result.warnings[0]).toContain('Invalid port');
   });
 
-  test('accepts valid dbMode', () => {
+  test('strips dbMode with deprecation warning', () => {
     const result = validateConfig({ dbMode: 'per-repo' });
     expect(result.valid).toBe(true);
-    expect(result.config.dbMode).toBe('per-repo');
+    expect(result.config).toEqual({});
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'dbMode' is deprecated");
   });
 
-  test('warns on invalid dbMode', () => {
-    const result = validateConfig({ dbMode: 'local' });
-    expect(result.valid).toBe(false);
-    expect(result.warnings[0]).toContain('Invalid dbMode');
+  test('strips dbMode and validates remaining fields', () => {
+    const result = validateConfig({ dbMode: 'global', transport: 'http' });
+    expect(result.valid).toBe(true);
+    expect(result.config.transport).toBe('http');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("'dbMode' is deprecated");
   });
 
   test('warns on non-object agent', () => {
@@ -87,8 +89,8 @@ describe('validateConfig', () => {
     expect(result.warnings[0]).toContain('Invalid agent');
   });
 
-  test('warns on non-string agent.runtime', () => {
-    const result = validateConfig({ agent: { runtime: 123 } });
+  test('warns on invalid agent.runtime', () => {
+    const result = validateConfig({ agent: { runtime: 'codex' } });
     expect(result.valid).toBe(false);
     expect(result.warnings[0]).toContain('agent.runtime');
   });
@@ -97,6 +99,23 @@ describe('validateConfig', () => {
     const result = validateConfig({ agent: { autoSetup: 'yes' } });
     expect(result.valid).toBe(false);
     expect(result.warnings[0]).toContain('agent.autoSetup');
+  });
+
+  test('accepts agent parallelism settings', () => {
+    const result = validateConfig({
+      agent: { maxParallelAgents: 10, agentsPerWorkflow: 3 },
+    });
+    expect(result.valid).toBe(true);
+    expect(result.config.agent?.maxParallelAgents).toBe(10);
+    expect(result.config.agent?.agentsPerWorkflow).toBe(3);
+  });
+
+  test('warns on out-of-range parallelism', () => {
+    const result = validateConfig({
+      agent: { maxParallelAgents: 100 },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.warnings[0]).toContain('agent.maxParallelAgents');
   });
 
   test('returns invalid for null input', () => {
@@ -111,9 +130,9 @@ describe('validateConfig', () => {
   });
 
   test('collects multiple warnings', () => {
-    const result = validateConfig({ transport: 'bad', port: -1, dbMode: 'bad' });
+    const result = validateConfig({ transport: 'bad', port: -1 });
     expect(result.valid).toBe(false);
-    expect(result.warnings.length).toBe(3);
+    expect(result.warnings.length).toBe(2);
   });
 
   test('ignores unknown keys without warning', () => {

--- a/packages/core/src/config/validate.ts
+++ b/packages/core/src/config/validate.ts
@@ -12,26 +12,38 @@ export function validateConfig(raw: unknown): ValidationResult {
     return { valid: false, config: {}, warnings: ['Config must be a JSON object'] };
   }
 
+  const deprecationWarnings: string[] = [];
+  const obj = raw as Record<string, unknown>;
+
+  // Strip deprecated fields before validation
+  if ('dbMode' in obj) {
+    deprecationWarnings.push(
+      "'dbMode' is deprecated and ignored. Database is always stored globally at ~/.caw/workflows.db.",
+    );
+    const { dbMode: _, ...rest } = obj;
+    raw = rest;
+  }
+
   const result = cawConfigSchema.safeParse(raw);
 
   if (result.success) {
-    return { valid: true, config: result.data, warnings: [] };
+    return { valid: true, config: result.data, warnings: deprecationWarnings };
   }
 
   // Zod parse failed — collect per-field warnings and build a partial config
   // by stripping only the invalid fields
-  const warnings: string[] = [];
-  const obj = raw as Record<string, unknown>;
+  const warnings: string[] = [...deprecationWarnings];
+  const rawObj = raw as Record<string, unknown>;
 
   for (const issue of result.error.issues) {
     const pathParts = issue.path.map(String);
     const path = pathParts.join('.');
-    const value = path ? getNestedValue(obj, pathParts) : obj;
+    const value = path ? getNestedValue(rawObj, pathParts) : rawObj;
     warnings.push(formatWarning(path, value, issue));
   }
 
   // Build partial config: re-parse with valid fields only by removing bad paths
-  const cleaned = structuredClone(obj);
+  const cleaned = structuredClone(rawObj);
   for (const issue of result.error.issues) {
     removeNestedKey(cleaned, issue.path.map(String));
   }

--- a/packages/core/src/db/connection.test.ts
+++ b/packages/core/src/db/connection.test.ts
@@ -44,16 +44,7 @@ describe('createConnection', () => {
 
 describe('getDbPath', () => {
   it('returns global path', () => {
-    const result = getDbPath('global');
+    const result = getDbPath();
     expect(result).toBe(join(homedir(), '.caw', 'workflows.db'));
-  });
-
-  it('returns per-repo path', () => {
-    const result = getDbPath('per-repo', '/home/user/my-project');
-    expect(result).toBe(join('/home/user/my-project', '.caw', 'workflows.db'));
-  });
-
-  it('throws if per-repo mode missing repoPath', () => {
-    expect(() => getDbPath('per-repo')).toThrow('repoPath is required for per-repo mode');
   });
 });

--- a/packages/core/src/db/connection.ts
+++ b/packages/core/src/db/connection.ts
@@ -23,14 +23,6 @@ export function createConnection(dbPath: string): DatabaseType {
   return db;
 }
 
-export function getDbPath(mode: 'global' | 'per-repo', repoPath?: string): string {
-  if (mode === 'global') {
-    return join(homedir(), '.caw', 'workflows.db');
-  }
-
-  if (!repoPath) {
-    throw new Error('repoPath is required for per-repo mode');
-  }
-
-  return join(repoPath, '.caw', 'workflows.db');
+export function getDbPath(): string {
+  return join(homedir(), '.caw', 'workflows.db');
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,15 +1,17 @@
 export type {
   AgentConfig,
+  AgentRuntime,
   CawConfig,
   CycleMode,
-  DbMode,
   LoadConfigResult,
   MergeMethod,
   PrConfig,
   TransportType as ConfigTransportType,
   ValidationResult,
+  WorkflowSourceType,
 } from './config/index';
 export {
+  AGENT_DEFAULTS,
   cawConfigSchema,
   ensureGitignore,
   getConfigPaths,

--- a/packages/core/src/services/agent.service.test.ts
+++ b/packages/core/src/services/agent.service.test.ts
@@ -7,7 +7,7 @@ import * as agentService from './agent.service';
 import * as workflowService from './workflow.service';
 
 function createTask(db: DatabaseType): string {
-  const wf = workflowService.create(db, { name: 'WF', source_type: 'issue' });
+  const wf = workflowService.create(db, { name: 'WF', source_type: 'custom' });
   workflowService.setPlan(db, wf.id, {
     summary: 'Plan',
     tasks: [{ name: 'Task' }],
@@ -383,7 +383,7 @@ describe('agentService', () => {
       });
 
       // Create a workflow with tasks
-      const wf = workflowService.create(db, { name: 'WF', source_type: 'issue' });
+      const wf = workflowService.create(db, { name: 'WF', source_type: 'custom' });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',
         tasks: [{ name: 'Task A' }, { name: 'Task B' }],
@@ -432,7 +432,7 @@ describe('agentService', () => {
         runtime: 'claude_code',
       });
 
-      const wf = workflowService.create(db, { name: 'WF', source_type: 'issue' });
+      const wf = workflowService.create(db, { name: 'WF', source_type: 'custom' });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',
         tasks: [{ name: 'Done Task' }, { name: 'Active Task' }],
@@ -547,7 +547,7 @@ describe('agentService', () => {
 
   describe('list with workflow_id', () => {
     it('filters by workflow_id', () => {
-      const wf = workflowService.create(db, { name: 'WF', source_type: 'issue' });
+      const wf = workflowService.create(db, { name: 'WF', source_type: 'custom' });
       agentService.register(db, { name: 'a', runtime: 'claude_code', workflow_id: wf.id });
       agentService.register(db, { name: 'b', runtime: 'claude_code' });
 

--- a/packages/core/src/services/checkpoint.service.test.ts
+++ b/packages/core/src/services/checkpoint.service.test.ts
@@ -9,7 +9,7 @@ import * as workflowService from './workflow.service';
 function setupWorkflowWithTask(db: DatabaseType): { workflowId: string; taskId: string } {
   const wf = workflowService.create(db, {
     name: 'Test Workflow',
-    source_type: 'issue',
+    source_type: 'custom',
   });
   workflowService.setPlan(db, wf.id, {
     summary: 'Test plan',
@@ -108,7 +108,7 @@ describe('checkpointService', () => {
     it('sequences are scoped per task', () => {
       const wf = workflowService.create(db, {
         name: 'Multi-task Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',

--- a/packages/core/src/services/context.service.test.ts
+++ b/packages/core/src/services/context.service.test.ts
@@ -17,7 +17,7 @@ interface TestData {
 function setupTestWorkflow(db: DatabaseType): TestData {
   const wf = workflowService.create(db, {
     name: 'Test Workflow',
-    source_type: 'issue',
+    source_type: 'custom',
     source_content: 'Implement feature X with acceptance criteria A, B, C',
   });
 
@@ -232,7 +232,7 @@ describe('contextService', () => {
     it('truncates large source_content to fit budget', () => {
       const wf = workflowService.create(db, {
         name: 'Large Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
         source_content: 'a'.repeat(10000), // Very large content
       });
 
@@ -254,7 +254,7 @@ describe('contextService', () => {
     it('respects custom max_tokens for more aggressive compression', () => {
       const wf = workflowService.create(db, {
         name: 'Budget Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
         source_content: 'a'.repeat(5000),
       });
 

--- a/packages/core/src/services/integration.test.ts
+++ b/packages/core/src/services/integration.test.ts
@@ -34,7 +34,7 @@ describe('cross-service integration', () => {
       // Create workflow
       const wf = workflowService.create(db, {
         name: 'Lifecycle Test',
-        source_type: 'issue',
+        source_type: 'custom',
         source_content: 'Build a feature end to end',
       });
       expect(wf.status).toBe('planning');
@@ -249,7 +249,7 @@ describe('cross-service integration', () => {
       // Create workflow with parallel tasks
       const wf = workflowService.create(db, {
         name: 'Multi-Agent Test',
-        source_type: 'issue',
+        source_type: 'custom',
         max_parallel_tasks: 2,
       });
 
@@ -498,7 +498,7 @@ describe('cross-service integration', () => {
       // Create source workflow with plan (3 tasks with deps)
       const srcWf = workflowService.create(db, {
         name: 'Source Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
 
       workflowService.setPlan(db, srcWf.id, {
@@ -587,7 +587,7 @@ describe('cross-service integration', () => {
       // Create workflow with max_parallel=2 and 4 parallel tasks
       const wf = workflowService.create(db, {
         name: 'Parallel Test',
-        source_type: 'issue',
+        source_type: 'custom',
         max_parallel_tasks: 2,
       });
 
@@ -634,7 +634,7 @@ describe('cross-service integration', () => {
       // Create workflow with sequential tasks
       const wf = workflowService.create(db, {
         name: 'Context Test',
-        source_type: 'issue',
+        source_type: 'custom',
         source_content: 'Build a widget with three steps',
       });
 

--- a/packages/core/src/services/message.service.test.ts
+++ b/packages/core/src/services/message.service.test.ts
@@ -122,7 +122,7 @@ describe('messageService', () => {
       const recipient = registerAgent(db, 'recipient');
 
       // Create real workflow + task for FK constraints
-      const wf = workflowService.create(db, { name: 'WF', source_type: 'issue' });
+      const wf = workflowService.create(db, { name: 'WF', source_type: 'custom' });
       workflowService.setPlan(db, wf.id, { summary: 'Plan', tasks: [{ name: 'Task' }] });
       const tasks = db.prepare('SELECT id FROM tasks WHERE workflow_id = ?').all(wf.id) as {
         id: string;
@@ -449,8 +449,8 @@ describe('messageService', () => {
       const sender = registerAgent(db, 'sender');
       const recipient = registerAgent(db, 'recipient');
 
-      const wf1 = workflowService.create(db, { name: 'WF1', source_type: 'issue' });
-      const wf2 = workflowService.create(db, { name: 'WF2', source_type: 'issue' });
+      const wf1 = workflowService.create(db, { name: 'WF1', source_type: 'custom' });
+      const wf2 = workflowService.create(db, { name: 'WF2', source_type: 'custom' });
 
       messageService.send(db, {
         sender_id: sender.id,

--- a/packages/core/src/services/orchestration.service.test.ts
+++ b/packages/core/src/services/orchestration.service.test.ts
@@ -10,7 +10,7 @@ import * as workflowService from './workflow.service';
 function createWorkflow(db: DatabaseType, name = 'Test Workflow', maxParallel = 2) {
   return workflowService.create(db, {
     name,
-    source_type: 'issue',
+    source_type: 'custom',
     max_parallel_tasks: maxParallel,
   });
 }

--- a/packages/core/src/services/repository.service.test.ts
+++ b/packages/core/src/services/repository.service.test.ts
@@ -127,17 +127,17 @@ describe('repositoryService', () => {
       const repo = repositoryService.register(db, { path: '/project' });
       workflowService.create(db, {
         name: 'WF1',
-        source_type: 'issue',
+        source_type: 'custom',
         repository_paths: ['/project'],
       });
       workflowService.create(db, {
         name: 'WF2',
-        source_type: 'issue',
+        source_type: 'custom',
         repository_paths: ['/project'],
       });
       workflowService.create(db, {
         name: 'WF3',
-        source_type: 'issue',
+        source_type: 'custom',
       });
 
       const workflows = repositoryService.getWorkflows(db, repo.id);

--- a/packages/core/src/services/task.service.test.ts
+++ b/packages/core/src/services/task.service.test.ts
@@ -16,7 +16,7 @@ interface SetupResult {
 function setupChainedTasks(db: DatabaseType): SetupResult {
   const wf = workflowService.create(db, {
     name: 'Test Workflow',
-    source_type: 'issue',
+    source_type: 'custom',
   });
   workflowService.setPlan(db, wf.id, {
     summary: 'Test plan',
@@ -122,7 +122,7 @@ describe('taskService', () => {
     it('ignores informs-only dependencies', () => {
       const wf = workflowService.create(db, {
         name: 'Inform Test',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',
@@ -161,7 +161,7 @@ describe('taskService', () => {
     it('returns empty arrays when no dependencies', () => {
       const wf = workflowService.create(db, {
         name: 'No Deps',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',
@@ -652,7 +652,7 @@ describe('taskService', () => {
 
       const wf2 = workflowService.create(db, {
         name: 'Other Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf2.id, {
         summary: 'Plan',
@@ -669,7 +669,7 @@ describe('taskService', () => {
 
       const wf2 = workflowService.create(db, {
         name: 'Other Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf2.id, {
         summary: 'Plan',
@@ -687,7 +687,7 @@ describe('taskService', () => {
     it('respects limit', () => {
       const wf = workflowService.create(db, {
         name: 'Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',
@@ -701,7 +701,7 @@ describe('taskService', () => {
     it('orders by sequence', () => {
       const wf = workflowService.create(db, {
         name: 'Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',

--- a/packages/core/src/services/template.service.test.ts
+++ b/packages/core/src/services/template.service.test.ts
@@ -58,7 +58,7 @@ describe('templateService', () => {
     it('creates a template from existing workflow', () => {
       const wf = workflowService.create(db, {
         name: 'Source Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',
@@ -84,7 +84,7 @@ describe('templateService', () => {
     it('captures estimated_complexity and files_likely_affected from workflow', () => {
       const wf = workflowService.create(db, {
         name: 'Source',
-        source_type: 'issue',
+        source_type: 'custom',
       });
       workflowService.setPlan(db, wf.id, {
         summary: 'Plan',
@@ -110,7 +110,7 @@ describe('templateService', () => {
     it('throws when providing both fromWorkflowId and template', () => {
       const wf = workflowService.create(db, {
         name: 'Source',
-        source_type: 'issue',
+        source_type: 'custom',
       });
 
       expect(() =>

--- a/packages/core/src/services/workflow.service.test.ts
+++ b/packages/core/src/services/workflow.service.test.ts
@@ -10,7 +10,7 @@ import * as workflowService from './workflow.service';
 function createBasicWorkflow(db: DatabaseType, overrides?: Partial<workflowService.CreateParams>) {
   return workflowService.create(db, {
     name: 'Test Workflow',
-    source_type: 'issue',
+    source_type: 'custom',
     ...overrides,
   });
 }
@@ -30,7 +30,7 @@ describe('workflowService', () => {
       const wf = createBasicWorkflow(db);
       expect(wf.id).toMatch(/^wf_[0-9a-z]{12}$/);
       expect(wf.name).toBe('Test Workflow');
-      expect(wf.source_type).toBe('issue');
+      expect(wf.source_type).toBe('custom');
       expect(wf.status).toBe('planning');
     });
 

--- a/packages/core/src/services/workflow.service.ts
+++ b/packages/core/src/services/workflow.service.ts
@@ -1,6 +1,11 @@
 import type { DatabaseType, SQLParam } from '../db/connection';
 import type { Task } from '../types/task';
-import type { Workflow, WorkflowStatus, WorkflowSummary } from '../types/workflow';
+import type {
+  Workflow,
+  WorkflowSourceType,
+  WorkflowStatus,
+  WorkflowSummary,
+} from '../types/workflow';
 import { taskId, workflowId } from '../utils/id';
 import { estimateTokens } from '../utils/tokens';
 import * as repositoryService from './repository.service';
@@ -57,7 +62,7 @@ export function create(db: DatabaseType, params: CreateParams): Workflow {
   const workflow: Workflow = {
     id: workflowId(),
     name: params.name,
-    source_type: params.source_type,
+    source_type: params.source_type as WorkflowSourceType,
     source_ref: params.source_ref ?? null,
     source_content: params.source_content ?? null,
     status: 'planning',

--- a/packages/core/src/services/workspace.service.test.ts
+++ b/packages/core/src/services/workspace.service.test.ts
@@ -9,7 +9,7 @@ import * as workspaceService from './workspace.service';
 function createWorkflowWithTasks(db: DatabaseType) {
   const wf = workflowService.create(db, {
     name: 'Test Workflow',
-    source_type: 'issue',
+    source_type: 'custom',
   });
   workflowService.setPlan(db, wf.id, {
     summary: 'Test plan',
@@ -353,7 +353,7 @@ describe('workspaceService', () => {
       const { workflow } = createWorkflowWithTasks(db);
       const wf2 = workflowService.create(db, {
         name: 'Other Workflow',
-        source_type: 'issue',
+        source_type: 'custom',
       });
 
       workspaceService.create(db, {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -6,6 +6,12 @@ export type { Repository } from './repository';
 export type { Session } from './session';
 export type { Task, TaskDependency, TaskDependencyType, TaskStatus } from './task';
 export type { WorkflowTemplate } from './template';
-export type { Workflow, WorkflowLockInfo, WorkflowStatus, WorkflowSummary } from './workflow';
+export type {
+  Workflow,
+  WorkflowLockInfo,
+  WorkflowSourceType,
+  WorkflowStatus,
+  WorkflowSummary,
+} from './workflow';
 export type { WorkflowRepository } from './workflow-repository';
 export type { Workspace, WorkspaceStatus } from './workspace';

--- a/packages/core/src/types/workflow.ts
+++ b/packages/core/src/types/workflow.ts
@@ -1,3 +1,5 @@
+export type WorkflowSourceType = 'prompt' | 'github_issue' | 'spec_file' | 'template' | 'custom';
+
 export type WorkflowStatus =
   | 'planning'
   | 'ready'
@@ -11,7 +13,7 @@ export type WorkflowStatus =
 export interface Workflow {
   id: string;
   name: string;
-  source_type: string;
+  source_type: WorkflowSourceType;
   source_ref: string | null;
   source_content: string | null;
   status: WorkflowStatus;
@@ -37,7 +39,7 @@ export interface WorkflowSummary {
   id: string;
   name: string;
   status: WorkflowStatus;
-  source_type: string;
+  source_type: WorkflowSourceType;
   created_at: number;
   updated_at: number;
 }

--- a/packages/mcp-server/src/bin/cli.ts
+++ b/packages/mcp-server/src/bin/cli.ts
@@ -6,9 +6,9 @@ import { createMcpServer, startServer } from '../server';
 const args = parseArgs(process.argv.slice(2));
 const config = resolveConfig(args);
 
-const dbPath = config.dbPath ?? getDbPath(config.dbMode, config.repoPath);
+const dbPath = config.dbPath ?? getDbPath();
 console.error(`caw: database at ${dbPath}`);
-console.error(`caw: transport=${config.transport}, mode=${config.dbMode}`);
+console.error(`caw: transport=${config.transport}`);
 
 const db = createConnection(dbPath);
 runMigrations(db);

--- a/packages/mcp-server/src/config.test.ts
+++ b/packages/mcp-server/src/config.test.ts
@@ -46,12 +46,4 @@ describe('resolveConfig', () => {
       );
     });
   });
-
-  describe('parseDbMode', () => {
-    it('rejects invalid db mode', () => {
-      expect(() => resolveConfig({ mode: 'repository' })).toThrow(
-        "Invalid db mode: 'repository'. Must be 'global' or 'per-repo'.",
-      );
-    });
-  });
 });

--- a/packages/mcp-server/src/config.ts
+++ b/packages/mcp-server/src/config.ts
@@ -1,12 +1,10 @@
 import { loadConfig } from '@caw/core';
 
 export type TransportType = 'stdio' | 'http';
-export type DbMode = 'global' | 'per-repo';
 
 export interface ServerConfig {
   transport: TransportType;
   port: number;
-  dbMode: DbMode;
   repoPath?: string;
   dbPath?: string;
   quiet?: boolean;
@@ -17,7 +15,6 @@ export const DEFAULT_PORT = 3100;
 export function resolveConfig(args: {
   transport?: string;
   port?: string;
-  mode?: string;
   repoPath?: string;
   dbPath?: string;
 }): ServerConfig {
@@ -35,14 +32,10 @@ export function resolveConfig(args: {
   const port = parsePort(
     args.port ?? process.env.CAW_PORT ?? (fc.port !== undefined ? String(fc.port) : undefined),
   );
-  const dbMode = parseDbMode(args.mode ?? process.env.CAW_DB_MODE ?? fc.dbMode ?? 'per-repo');
-  const repoPath =
-    args.repoPath ??
-    process.env.CAW_REPO_PATH ??
-    (dbMode === 'per-repo' ? process.cwd() : undefined);
+  const repoPath = args.repoPath ?? process.env.CAW_REPO_PATH ?? process.cwd();
   const dbPath = args.dbPath ?? process.env.CAW_DB_PATH;
 
-  return { transport, port, dbMode, repoPath, dbPath };
+  return { transport, port, repoPath, dbPath };
 }
 
 function parseTransport(value: string): TransportType {
@@ -57,9 +50,4 @@ function parsePort(value: string | undefined): number {
     throw new Error(`Invalid port: '${value}'. Must be an integer between 1 and 65535.`);
   }
   return port;
-}
-
-function parseDbMode(value: string): DbMode {
-  if (value === 'global' || value === 'per-repo') return value;
-  throw new Error(`Invalid db mode: '${value}'. Must be 'global' or 'per-repo'.`);
 }

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -1,4 +1,4 @@
-export type { DbMode, ServerConfig, TransportType } from './config';
+export type { ServerConfig, TransportType } from './config';
 export { DEFAULT_PORT, resolveConfig } from './config';
 export type { McpHttpHandler, McpServerOptions, StartServerResult } from './server';
 export { createHttpHandler, createMcpServer, startServer } from './server';

--- a/packages/mcp-server/src/tools/workflow.ts
+++ b/packages/mcp-server/src/tools/workflow.ts
@@ -93,7 +93,7 @@ export const register: ToolRegistrar = (server, db) => {
       inputSchema: {
         name: z.string().describe('Workflow name'),
         source_type: z
-          .enum(['prompt', 'github_issue', 'linear', 'jira', 'custom'])
+          .enum(['prompt', 'github_issue', 'spec_file', 'custom'])
           .describe('Source type'),
         source_ref: z.string().optional().describe('URL or identifier'),
         source_content: z.string().describe('The actual prompt/issue content'),

--- a/packages/rest-api/src/api.test.ts
+++ b/packages/rest-api/src/api.test.ts
@@ -530,7 +530,6 @@ describe('setup routes', () => {
     expect(checkNames).toContain('mcp_server');
     expect(checkNames).toContain('claude_md');
     expect(checkNames).toContain('config_file');
-    expect(checkNames).toContain('gitignore');
 
     // Each check should have the required structure
     for (const check of body.data.checks) {

--- a/packages/rest-api/src/routes/setup.ts
+++ b/packages/rest-api/src/routes/setup.ts
@@ -17,6 +17,13 @@ export interface SetupDiagnostics {
 }
 
 export function registerSetupRoutes(router: Router, db: DatabaseType) {
+  // Get initialization status
+  router.get('/api/setup/status', () => {
+    const globalConfig = join(homedir(), '.caw', 'config.json');
+    const initialized = existsSync(globalConfig);
+    return ok({ initialized });
+  });
+
   // Get setup diagnostics
   router.get('/api/setup/diagnostics', () => {
     const checks: DiagnosticCheck[] = [];
@@ -91,57 +98,22 @@ export function registerSetupRoutes(router: Router, db: DatabaseType) {
       });
     }
 
-    // Check 4: Config file exists (.caw/config.json)
+    // Check 4: Config file exists (~/.caw/config.json)
     try {
-      const cwd = process.cwd();
-      const configPath = join(cwd, '.caw', 'config.json');
-      const configExists = existsSync(configPath);
+      const globalConfigPath = join(homedir(), '.caw', 'config.json');
+      const configExists = existsSync(globalConfigPath);
       checks.push({
         name: 'config_file',
         status: configExists ? 'pass' : 'fail',
         message: configExists
-          ? 'Config file exists at .caw/config.json'
-          : 'Config file not found at .caw/config.json',
+          ? `Config file exists at ${globalConfigPath}`
+          : `Config file not found at ${globalConfigPath}. Run 'caw init' to create it.`,
       });
     } catch (err) {
       checks.push({
         name: 'config_file',
         status: 'fail',
         message: `Failed to check config file: ${err instanceof Error ? err.message : String(err)}`,
-      });
-    }
-
-    // Check 5: .gitignore includes .caw/
-    try {
-      const cwd = process.cwd();
-      const gitignorePath = join(cwd, '.gitignore');
-      const gitignoreExists = existsSync(gitignorePath);
-
-      if (!gitignoreExists) {
-        checks.push({
-          name: 'gitignore',
-          status: 'fail',
-          message: '.gitignore file not found',
-        });
-      } else {
-        const content = readFileSync(gitignorePath, 'utf-8');
-        const hasCawEntry = content.split('\n').some((line) => {
-          const trimmed = line.trim();
-          return trimmed === '.caw/' || trimmed === '.caw' || trimmed.startsWith('.caw/');
-        });
-        checks.push({
-          name: 'gitignore',
-          status: hasCawEntry ? 'pass' : 'fail',
-          message: hasCawEntry
-            ? '.gitignore includes .caw/ directory'
-            : '.gitignore does not include .caw/ directory',
-        });
-      }
-    } catch (err) {
-      checks.push({
-        name: 'gitignore',
-        status: 'fail',
-        message: `Failed to check .gitignore: ${err instanceof Error ? err.message : String(err)}`,
       });
     }
 

--- a/packages/spawner/src/index.ts
+++ b/packages/spawner/src/index.ts
@@ -27,7 +27,10 @@ export type { QualityHooksConfig } from './quality-hooks';
 export { installQualityHooks, removeQualityHooks } from './quality-hooks';
 export {
   clearRegistry,
+  decrementGlobalAgentCount,
+  getGlobalAgentCount,
   getSpawner,
+  incrementGlobalAgentCount,
   listSpawners,
   registerSpawner,
   unregisterSpawner,
@@ -35,6 +38,7 @@ export {
 export type { AutoResumeResult, ResumeOptions } from './resume';
 export { resumeWorkflows } from './resume';
 export { WorkflowRunner } from './runner';
+export type { WorkflowSpawnerOptions } from './spawner.service';
 export { WorkflowSpawner } from './spawner.service';
 export type {
   StagnationConfig,

--- a/packages/spawner/src/pool.ts
+++ b/packages/spawner/src/pool.ts
@@ -6,6 +6,11 @@ import { runIntentJudge } from './intent-judge';
 import { routeTask } from './model-router';
 import { buildAgentSystemPrompt } from './prompt';
 import { installQualityHooks } from './quality-hooks';
+import {
+  decrementGlobalAgentCount,
+  getGlobalAgentCount,
+  incrementGlobalAgentCount,
+} from './registry';
 import type { AgentHandle, SpawnerConfig, SpawnerEvent, SpawnerEventData } from './types';
 
 const MAX_RETRIES = 3;
@@ -32,6 +37,7 @@ export class AgentPool {
     private readonly config: SpawnerConfig,
     private readonly workflow: Pick<Workflow, 'id' | 'name' | 'plan_summary' | 'source_content'>,
     private readonly humanAgentId: string | null = null,
+    private readonly globalMaxAgents: number = 50,
   ) {}
 
   on<E extends SpawnerEvent>(event: E, listener: EventListener<E>): void {
@@ -201,6 +207,7 @@ export class AgentPool {
     }, HEARTBEAT_INTERVAL_MS);
     this.heartbeatTimers.set(agent.id, heartbeatTimer);
 
+    incrementGlobalAgentCount();
     this.emit('agent_started', { agentId: agent.id, taskId: task.id });
 
     // Run in background (don't await here)
@@ -252,7 +259,9 @@ export class AgentPool {
   }
 
   hasCapacity(): boolean {
-    return this.getActiveCount() < this.getMaxAgents();
+    return (
+      this.getActiveCount() < this.getMaxAgents() && getGlobalAgentCount() < this.globalMaxAgents
+    );
   }
 
   setMaxAgents(n: number): void {
@@ -344,6 +353,8 @@ export class AgentPool {
   }
 
   private cleanupAgent(agentId: string): void {
+    decrementGlobalAgentCount();
+
     // Stop heartbeat
     const timer = this.heartbeatTimers.get(agentId);
     if (timer) {

--- a/packages/spawner/src/registry.ts
+++ b/packages/spawner/src/registry.ts
@@ -2,6 +2,8 @@ import type { WorkflowSpawner } from './spawner.service';
 
 const spawnerRegistry = new Map<string, WorkflowSpawner>();
 
+let globalActiveAgents = 0;
+
 export function registerSpawner(workflowId: string, spawner: WorkflowSpawner): void {
   spawnerRegistry.set(workflowId, spawner);
 }
@@ -20,4 +22,19 @@ export function listSpawners(): Map<string, WorkflowSpawner> {
 
 export function clearRegistry(): void {
   spawnerRegistry.clear();
+  globalActiveAgents = 0;
+}
+
+export function getGlobalAgentCount(): number {
+  return globalActiveAgents;
+}
+
+export function incrementGlobalAgentCount(): void {
+  globalActiveAgents++;
+}
+
+export function decrementGlobalAgentCount(): void {
+  if (globalActiveAgents > 0) {
+    globalActiveAgents--;
+  }
 }

--- a/packages/spawner/src/spawner.service.ts
+++ b/packages/spawner/src/spawner.service.ts
@@ -25,6 +25,10 @@ import type {
 
 const POLL_INTERVAL_MS = 5_000;
 
+export interface WorkflowSpawnerOptions {
+  globalMaxAgents?: number;
+}
+
 export class WorkflowSpawner {
   private pool: AgentPool | null = null;
   private pollTimer: ReturnType<typeof setInterval> | null = null;
@@ -33,11 +37,14 @@ export class WorkflowSpawner {
   private listeners = new Map<SpawnerEvent, Set<EventListener<SpawnerEvent>>>();
   private humanAgentId: string | null = null;
   private emittedQueryTasks = new Set<string>();
+  private readonly globalMaxAgents: number;
 
   constructor(
     private readonly db: DatabaseType,
     private readonly config: SpawnerConfig,
+    options?: WorkflowSpawnerOptions,
   ) {
+    this.globalMaxAgents = options?.globalMaxAgents ?? 50;
     this.spawnerMetadata = {
       spawner_id: generateId('sp'),
       max_agents: config.maxAgents,
@@ -131,6 +138,7 @@ export class WorkflowSpawner {
         source_content: workflowData.source_content,
       },
       this.humanAgentId,
+      this.globalMaxAgents,
     );
 
     // Forward pool events
@@ -246,6 +254,7 @@ export class WorkflowSpawner {
         source_content: workflowData.source_content,
       },
       this.humanAgentId,
+      this.globalMaxAgents,
     );
     this.forwardPoolEvents();
 

--- a/scripts/seed-qa.ts
+++ b/scripts/seed-qa.ts
@@ -19,7 +19,7 @@ import {
   workflowService,
 } from '../packages/core/src/index';
 
-const dbPath = getDbPath('per-repo', process.cwd());
+const dbPath = getDbPath();
 console.log(`Seeding Q&A scenario into: ${dbPath}`);
 
 const db = createConnection(dbPath);

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -28,7 +28,7 @@ import {
   workspaceService,
 } from '../packages/core/src/index';
 
-const dbPath = getDbPath('per-repo', process.cwd());
+const dbPath = getDbPath();
 console.log(`Seeding database at: ${dbPath}`);
 
 const db = createConnection(dbPath);
@@ -174,7 +174,7 @@ console.log(`Workflow 1: ${wf1.id} — "Add user authentication" (in_progress, $
 // Workflow 2: "Refactor database layer" — completed
 const wf2 = workflowService.create(db, {
   name: 'Refactor database layer',
-  source_type: 'issue',
+  source_type: 'github_issue',
   source_ref: 'https://github.com/example/acme-api/issues/42',
   source_content: 'Replace raw SQL queries with a query builder for better maintainability.',
   repository_paths: [path.join(process.cwd(), '..', 'acme-api')],


### PR DESCRIPTION
## Summary

- **Remove `dbMode`**: Database is always global at `~/.caw/workflows.db`. `getDbPath()` takes no arguments. Old `dbMode` in config files is stripped with a deprecation warning for backward compatibility.
- **Constrain agent runtime**: `agent.runtime` is now `z.enum(['claude-code'])` instead of free-form string. Added `maxParallelAgents` (default 10) and `agentsPerWorkflow` (default 3) config options with `AGENT_DEFAULTS` constant.
- **Type `WorkflowSourceType`**: New enum `'prompt' | 'github_issue' | 'spec_file' | 'template' | 'custom'` applied to `Workflow.source_type` and `WorkflowSummary.source_type`. MCP tool enum updated (removed `linear`/`jira`, added `spec_file`).
- **Simplify CLI init**: Always targets `~/.caw/`, removed `--global` flag and `dbMode` prompt. Added initialization check (exits with guidance if `~/.caw/config.json` missing).
- **Global agent limiting**: Added global agent counter to spawner registry. `AgentPool` checks both per-workflow and global capacity limits.
- **Desktop updates**: Init detection banner in layout, `run_init` Tauri command, settings page removes dbMode/adds parallelism inputs, templates page shows registered repos.
- **MCP server**: Removed `DbMode` type, `parseDbMode()`, simplified `resolveConfig()`.

### Packages changed
- `@caw/core` — schema, config, DB connection, types, services, tests
- `@caw/mcp-server` — config, tools, CLI entry
- `@caw/rest-api` — setup routes, tests
- `@caw/spawner` — registry, pool, spawner service
- `@caw/cli` — CLI entry, init command
- `@caw/desktop` — API client, layout, settings, templates, Tauri backend

## Testing
- [x] Tests added/updated (44 files changed)
- [x] All tests passing (`bun run test` — all packages green)
- [x] `bun run build` passes
- [x] `bun run lint` passes
- [x] Backward compat: old configs with `dbMode` load with deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)